### PR TITLE
Add scheduler for personal GH tm-* branches

### DIFF
--- a/buildbot/maria-master.cfg
+++ b/buildbot/maria-master.cfg
@@ -564,6 +564,14 @@ c['schedulers'].append(Triggerable(
                       "kvm-deb-stretch-amd64",
                       ]))
 
+# Created by Teodor to build personal tm- branches on macos-10-13
+# slave
+c['schedulers'].append(AnyBranchScheduler(
+        name="shinnok-sched-macos",
+        change_filter=ChangeFilter(branch="tm-"),
+        treeStableTimer=15,
+        builderNames=["macos-10-13"]))
+
 execfile("/etc/buildbot/builders/qa/qa_schedulers.py");
 
 #


### PR DESCRIPTION
To be built on newly added macos-10-13 builder. Currently my slave is only used for kvm-sched-mainonly-10.0+ by the looks of it. Example branch:

https://github.com/shinnok/server/commits/tm-10.3-macfixes
https://buildbot.askmonty.org/buildbot/buildslaves/shinnok-bld