### PR TITLE
Add rate limiting

### DIFF
--- a/buildbot.mariadb.org/util/nginx.conf
+++ b/buildbot.mariadb.org/util/nginx.conf
@@ -25,6 +25,9 @@ server {
 	ssl_session_timeout 1d;
 	# Force https - Enable HSTS
 	add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;" always;
+        
+      # Rate limiting
+      limit_req_zone $request_uri zone=default:10m rate=30r/m burst=5 nodelay;
 
 	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
@@ -34,6 +37,9 @@ server {
 	proxy_set_header X-Forwarded-Host  $host;
 
 	location / {
+              # Rate limiting
+              limit_req zone=default;
+
 		# Reverse proxy settings
 		include proxy_params;
 		proxy_pass http://localhost:8010;
@@ -41,13 +47,19 @@ server {
 
 	# Server sent event (sse) settings
 	location /sse {
+              # Rate limiting
+              limit_req zone=default;
+
 		proxy_buffering off;
 		proxy_pass http://localhost:8010/sse;
 	}
 
 	# Websocket settings
 	location /ws {
-		proxy_http_version 1.1;
+              # Rate limiting
+              limit_req zone=default;
+
+	        proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";
 		proxy_pass http://localhost:8010/ws;
@@ -78,9 +90,15 @@ server {
 	ssl_certificate_key /etc/letsencrypt/live/ci.mariadb.org/privkey.pem;
 	# Force https - Enable HSTS
 	add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;" always;
+      # Rate limiting
+      limit_req_zone $request_uri zone=default:10m rate=30r/m burst=5 nodelay;
 
 	root /srv/buildbot/bb_builds/;
 	autoindex on;
+      location / {
+            # Rate limiting
+            limit_req zone=default;
+      }
 }
 
 


### PR DESCRIPTION
After testing with siege : `siege -v -r 4 -c 5 buildbot.mariadb.org` have seen that there is no rate limiting.
This patch is adding a rate limiting  to buildbot.mariadb.org. 
@shinnok  please review and let me know should the same be added to ci.mariadb.org.