### PR TITLE
Add trailing slash in proxy path

### DIFF
--- a/buildbot.mariadb.org/util/nginx.conf
+++ b/buildbot.mariadb.org/util/nginx.conf
@@ -43,7 +43,7 @@ server {
 
 		# Reverse proxy settings
 		include proxy_params;
-		proxy_pass http://localhost:8010;
+		proxy_pass http://localhost:8010/;
 	}
 
 	# Server sent event (sse) settings
@@ -51,7 +51,7 @@ server {
 		limit_req zone=default burst=10 nodelay;
 
 		proxy_buffering off;
-		proxy_pass http://localhost:8010/sse;
+		proxy_pass http://localhost:8010/sse/;
 	}
 
 	# Websocket settings
@@ -61,7 +61,7 @@ server {
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";
-		proxy_pass http://localhost:8010/ws;
+		proxy_pass http://localhost:8010/ws/;
 		proxy_read_timeout 6000s;
 	}
 }


### PR DESCRIPTION
In order to be consistent with proxy path `/`character is added at the
end of proxy path.
Instead nginx assumes original request path.