### PR TITLE
Add default parameters managed by cerbot and dhparam for LE

### DIFF
--- a/buildbot.mariadb.org/util/nginx.conf
+++ b/buildbot.mariadb.org/util/nginx.conf
@@ -23,6 +23,8 @@ server {
 	ssl on;
 	ssl_certificate /etc/letsencrypt/live/buildbot.mariadb.org/fullchain.pem;
 	ssl_certificate_key /etc/letsencrypt/live/buildbot.mariadb.org/privkey.pem;
+      include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+      ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 	# put a one day session timeout for websockets to stay longer
 	ssl_session_cache   shared:SSL:10m;
 	ssl_session_timeout 1d;
@@ -90,6 +92,8 @@ server {
 	ssl on;
 	ssl_certificate /etc/letsencrypt/live/ci.mariadb.org/fullchain.pem;
 	ssl_certificate_key /etc/letsencrypt/live/ci.mariadb.org/privkey.pem;
+      include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+      ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 	# Force https - Enable HSTS
 	add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;" always;
 


### PR DESCRIPTION
-Use default parameters in `/etc/letsencrypt/options-ssl-nginx.conf` file which are created and managed by certbot
-Security: Use Diffie Hellman key exchange which is again created and managed by certbot
This is given by default when installing letsencrypt using certbot with already specified domains.
@shinnok please review