### PR TITLE
Dockerfiles - minor changes

### DIFF
--- a/buildbot.mariadb.org/dockerfiles/centos-7.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/centos-7.dockerfile
@@ -5,7 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       centos:7
-MAINTAINER MariaDB Buildbot maintainers
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 USER root
 

--- a/buildbot.mariadb.org/dockerfiles/debian-9.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/debian-9.dockerfile
@@ -5,7 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       debian:9
-MAINTAINER MariaDB Buildbot maintainers
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive

--- a/buildbot.mariadb.org/dockerfiles/debian-9.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/debian-9.dockerfile
@@ -7,8 +7,6 @@
 FROM       debian:9
 MAINTAINER MariaDB Buildbot maintainers
 
-USER root
-
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,21 +30,21 @@ RUN useradd -ms /bin/bash buildbot && \
     mkdir /buildbot && \
     chown -R buildbot /buildbot && \
     curl -o /buildbot/buildbot.tac https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
-WORKDIR /buildbot
 
 # autobake-deb will need sudo rights
 RUN usermod -a -G sudo buildbot
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Upgrade pip and install packages
-RUN pip3 install -U pip virtualenv
-RUN pip3 install buildbot-worker
-RUN pip3 --no-cache-dir install 'twisted[tls]'
+RUN pip3 install -U pip virtualenv && \
+    pip3 install buildbot-worker && \
+    pip3 --no-cache-dir install 'twisted[tls]'
 
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),
 # so we need to simulate that here.  See https://github.com/Yelp/dumb-init
-RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb -Lo /tmp/init.deb && dpkg -i /tmp/init.deb
+RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
+    rm -rf /var/lib/apt/lists*
 
 USER buildbot
 CMD ["/usr/bin/dumb-init", "twistd", "--pidfile=", "-ny", "buildbot.tac"]

--- a/buildbot.mariadb.org/dockerfiles/debian-9.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/debian-9.dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
 RUN useradd -ms /bin/bash buildbot && \
     mkdir /buildbot && \
     chown -R buildbot /buildbot && \
-    curl -o /buildbot/buildbot.tac https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
+    curl -o /buildbot/buildbot.tac \
+    https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
 
 # autobake-deb will need sudo rights
 RUN usermod -a -G sudo buildbot
@@ -43,7 +44,8 @@ RUN pip3 install -U pip virtualenv && \
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),
 # so we need to simulate that here.  See https://github.com/Yelp/dumb-init
-RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
+RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb \
+    -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
     rm -rf /var/lib/apt/lists*
 
 USER buildbot

--- a/buildbot.mariadb.org/dockerfiles/fedora-28.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/fedora-28.dockerfile
@@ -5,7 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       fedora:28
-MAINTAINER MariaDB Buildbot maintainers
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 USER root
 

--- a/buildbot.mariadb.org/dockerfiles/opensuse-15.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/opensuse-15.dockerfile
@@ -5,7 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       opensuse/leap
-MAINTAINER MariaDB Buildbot maintainers
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 USER root
 

--- a/buildbot.mariadb.org/dockerfiles/opensuse-42.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/opensuse-42.dockerfile
@@ -5,7 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       opensuse/leap:42.3
-MAINTAINER MariaDB Buildbot maintainers
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 USER root
 

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1404.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1404.dockerfile
@@ -7,8 +7,6 @@
 FROM       ubuntu:14.04
 MAINTAINER MariaDB Buildbot maintainers
 
-USER root
-
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,21 +30,21 @@ RUN useradd -ms /bin/bash buildbot && \
     mkdir /buildbot && \
     chown -R buildbot /buildbot && \
     curl -o /buildbot/buildbot.tac https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
-WORKDIR /buildbot
 
 # autobake-deb will need sudo rights
 RUN usermod -a -G sudo buildbot
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Upgrade pip and install packages
-RUN pip3 install -U pip virtualenv
-RUN pip3 install buildbot-worker
-RUN pip3 --no-cache-dir install 'twisted[tls]'
+RUN pip3 install -U pip virtualenv && \
+    pip3 install buildbot-worker && \
+    pip3 --no-cache-dir install 'twisted[tls]'
 
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),
 # so we need to simulate that here.  See https://github.com/Yelp/dumb-init
-RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb -Lo /tmp/init.deb && dpkg -i /tmp/init.deb
+RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
+    rm -rf /var/lib/apt/lists*
 
 USER buildbot
 CMD ["/usr/bin/dumb-init", "twistd", "--pidfile=", "-ny", "buildbot.tac"]

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1404.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1404.dockerfile
@@ -5,7 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       ubuntu:14.04
-MAINTAINER MariaDB Buildbot maintainers
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1404.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1404.dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
 RUN useradd -ms /bin/bash buildbot && \
     mkdir /buildbot && \
     chown -R buildbot /buildbot && \
-    curl -o /buildbot/buildbot.tac https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
+    curl -o /buildbot/buildbot.tac \
+    https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
 
 # autobake-deb will need sudo rights
 RUN usermod -a -G sudo buildbot
@@ -43,7 +44,8 @@ RUN pip3 install -U pip virtualenv && \
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),
 # so we need to simulate that here.  See https://github.com/Yelp/dumb-init
-RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
+RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb \
+    -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
     rm -rf /var/lib/apt/lists*
 
 USER buildbot

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1604.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1604.dockerfile
@@ -5,7 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       ubuntu:16.04
-MAINTAINER MariaDB Buildbot maintainers
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1604.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1604.dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
 RUN useradd -ms /bin/bash buildbot && \
     mkdir /buildbot && \
     chown -R buildbot /buildbot && \
-    curl -o /buildbot/buildbot.tac https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
+    curl -o /buildbot/buildbot.tac \
+    https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
 
 # autobake-deb will need sudo rights
 RUN usermod -a -G sudo buildbot
@@ -43,7 +44,8 @@ RUN pip3 install -U pip virtualenv && \
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),
 # so we need to simulate that here.  See https://github.com/Yelp/dumb-init
-RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
+RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb \
+    -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
     rm -rf /var/lib/apt/lists*
 
 USER buildbot

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1804.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1804.dockerfile
@@ -7,8 +7,6 @@
 FROM       ubuntu:18.04
 MAINTAINER MariaDB Buildbot maintainers
 
-USER root
-
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,21 +30,21 @@ RUN useradd -ms /bin/bash buildbot && \
     mkdir /buildbot && \
     chown -R buildbot /buildbot && \
     curl -o /buildbot/buildbot.tac https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
-WORKDIR /buildbot
 
 # autobake-deb will need sudo rights
 RUN usermod -a -G sudo buildbot
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Upgrade pip and install packages
-RUN pip3 install -U pip virtualenv
-RUN pip3 install buildbot-worker
-RUN pip3 --no-cache-dir install 'twisted[tls]'
+RUN pip3 install -U pip virtualenv && \
+    pip3 install buildbot-worker && \
+    pip3 --no-cache-dir install 'twisted[tls]'
 
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),
 # so we need to simulate that here.  See https://github.com/Yelp/dumb-init
-RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb -Lo /tmp/init.deb && dpkg -i /tmp/init.deb
+RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
+    rm -rf /var/lib/apt/lists*
 
 USER buildbot
 CMD ["/usr/bin/dumb-init", "twistd", "--pidfile=", "-ny", "buildbot.tac"]

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1804.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1804.dockerfile
@@ -5,7 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       ubuntu:18.04
-MAINTAINER MariaDB Buildbot maintainers
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1804.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1804.dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
 RUN useradd -ms /bin/bash buildbot && \
     mkdir /buildbot && \
     chown -R buildbot /buildbot && \
-    curl -o /buildbot/buildbot.tac https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
+    curl -o /buildbot/buildbot.tac \
+    https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/dockerfiles/buildbot.tac
 
 # autobake-deb will need sudo rights
 RUN usermod -a -G sudo buildbot
@@ -43,7 +44,8 @@ RUN pip3 install -U pip virtualenv && \
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),
 # so we need to simulate that here.  See https://github.com/Yelp/dumb-init
-RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
+RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb \
+    -Lo /tmp/init.deb && dpkg -i /tmp/init.deb && \
     rm -rf /var/lib/apt/lists*
 
 USER buildbot


### PR DESCRIPTION
- By creating from official image root user is redundant 
- `WORKDIR` it is not used by docker nor by application
- Decrease number of layers and generated commits created by `RUN` command
- Empty the package list for saving the space for the image
- Try to fit into smaller code width
- Remove deprecated maintainer instruction https://docs.docker.com/engine/reference/builder/#/maintainer-deprecated

Please let me know should this be implemented for other images.
@shinnok please review