### PR TITLE
Disable insecure TLS 1.0 protocol

### DIFF
--- a/buildbot.mariadb.org/util/nginx.conf
+++ b/buildbot.mariadb.org/util/nginx.conf
@@ -26,6 +26,8 @@ server {
 	# put a one day session timeout for websockets to stay longer
 	ssl_session_cache   shared:SSL:10m;
 	ssl_session_timeout 1d;
+        ssl_protocols TLSv1.1 TLSv1.2;
+
 	# Force https - Enable HSTS
 	add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;" always;
 	# Rate limiting
@@ -104,6 +106,8 @@ server {
 	ssl on;
 	ssl_certificate /etc/letsencrypt/live/ci.mariadb.org/fullchain.pem;
 	ssl_certificate_key /etc/letsencrypt/live/ci.mariadb.org/privkey.pem;
+        ssl_protocols TLSv1.1 TLSv1.2;
+
 	# Force https - Enable HSTS
 	add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;" always;
 	


### PR DESCRIPTION
From https://www.ssllabs.com/ssltest/analyze.html?d=buildbot.mariadb.org can be seen that TLS1.0 is still enabled. This patch should remove TLS 1.0.
@shinnok  please review