### PR TITLE
Minor changes in docker files

### DIFF
--- a/buildbot.mariadb.org/dockerfiles/centos-7.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/centos-7.dockerfile
@@ -5,9 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       centos:7
-MAINTAINER MariaDB Buildbot maintainers
-
-USER root
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # Install updates and required packages
 RUN yum -y --enablerepo=extras install epel-release && \

--- a/buildbot.mariadb.org/dockerfiles/debian-9.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/debian-9.dockerfile
@@ -5,9 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       debian:9
-MAINTAINER MariaDB Buildbot maintainers
-
-USER root
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive
@@ -39,9 +37,9 @@ RUN usermod -a -G sudo buildbot
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Upgrade pip and install packages
-RUN pip3 install -U pip virtualenv
-RUN pip3 install buildbot-worker
-RUN pip3 --no-cache-dir install 'twisted[tls]'
+RUN pip3 install -U pip virtualenv && \
+    pip3 install buildbot-worker && \
+    pip3 --no-cache-dir install 'twisted[tls]'
 
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),

--- a/buildbot.mariadb.org/dockerfiles/fedora-28.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/fedora-28.dockerfile
@@ -5,9 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       fedora:28
-MAINTAINER MariaDB Buildbot maintainers
-
-USER root
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # Install updates and required packages
 RUN dnf -y upgrade && \

--- a/buildbot.mariadb.org/dockerfiles/opensuse-15.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/opensuse-15.dockerfile
@@ -5,9 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       opensuse/leap
-MAINTAINER MariaDB Buildbot maintainers
-
-USER root
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # Install updates and required packages
 RUN zypper update -y && \

--- a/buildbot.mariadb.org/dockerfiles/opensuse-42.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/opensuse-42.dockerfile
@@ -5,9 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       opensuse/leap:42.3
-MAINTAINER MariaDB Buildbot maintainers
-
-USER root
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # Install updates and required packages
 RUN zypper update -y && \

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1404.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1404.dockerfile
@@ -5,9 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       ubuntu:14.04
-MAINTAINER MariaDB Buildbot maintainers
-
-USER root
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive
@@ -39,9 +37,9 @@ RUN usermod -a -G sudo buildbot
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Upgrade pip and install packages
-RUN pip3 install -U pip virtualenv
-RUN pip3 install buildbot-worker
-RUN pip3 --no-cache-dir install 'twisted[tls]'
+RUN pip3 install -U pip virtualenv && \
+    pip3 install buildbot-worker && \
+    pip3 --no-cache-dir install 'twisted[tls]'
 
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1604.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1604.dockerfile
@@ -5,9 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       ubuntu:16.04
-MAINTAINER MariaDB Buildbot maintainers
-
-USER root
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive
@@ -40,9 +38,9 @@ RUN usermod -a -G sudo buildbot
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Upgrade pip and install packages
-RUN pip3 install -U pip virtualenv
-RUN pip3 install buildbot-worker
-RUN pip3 --no-cache-dir install 'twisted[tls]'
+RUN pip3 install -U pip virtualenv && \
+    pip3 install buildbot-worker && \
+    pip3 --no-cache-dir install 'twisted[tls]'
 
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),

--- a/buildbot.mariadb.org/dockerfiles/ubuntu-1804.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/ubuntu-1804.dockerfile
@@ -5,9 +5,7 @@
 # and MariaDB build dependencies
 
 FROM       ubuntu:18.04
-MAINTAINER MariaDB Buildbot maintainers
-
-USER root
+LABEL maintainer="MariaDB Buildbot maintainers"
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive
@@ -39,9 +37,9 @@ RUN usermod -a -G sudo buildbot
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Upgrade pip and install packages
-RUN pip3 install -U pip virtualenv
-RUN pip3 install buildbot-worker
-RUN pip3 --no-cache-dir install 'twisted[tls]'
+RUN pip3 install -U pip virtualenv && \
+    pip3 install buildbot-worker && \
+    pip3 --no-cache-dir install 'twisted[tls]'
 
 # Test runs produce a great quantity of dead grandchild processes.  In a
 # non-docker environment, these are automatically reaped by init (process 1),


### PR DESCRIPTION
- Remove deprecated `MAINTAINER` keyword, add `LABEL` instead (all distros)
- Remove the `USER root` it is by default (all distros)
- Decrease number of layers and generated commits created by `RUN` command
(for debian, ubuntu based distros, other distros have piped layers)
@shinnok  please review 