### PR TITLE
Adding webhooks to mirmon

### DIFF
--- a/monitoring/mirmon/README.md
+++ b/monitoring/mirmon/README.md
@@ -1,0 +1,2 @@
+See https://fi.mariadb.org/wiki/Mariadb.org_downloads_page#Adding_a_mirror for
+the documentation.

--- a/monitoring/mirmon/webhook/mirmon_update.sh
+++ b/monitoring/mirmon/webhook/mirmon_update.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+set -o posix
+
+err() {
+  echo >&2 "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*"
+  exit 1
+}
+
+# necessary commands
+for cmd in wget mirmon; do
+  command -v $cmd >/dev/null || err "$cmd command not found"
+done
+
+typeset -r var_mirror_list_url="https://github.com/$1/raw/$2/monitoring/mirmon/mariadb_mirror_list"
+
+wget "$var_mirror_list_url" -O /usr/local/share/mariadb_mirror_list || err "Unable to get mirror list"
+mirmon -q -get update >/opt/webhooks/mirmon_call.log

--- a/monitoring/mirmon/webhook/webhook.yaml
+++ b/monitoring/mirmon/webhook/webhook.yaml
@@ -1,0 +1,23 @@
+- id: mirmon_update_list
+  execute-command: /opt/webhooks/mirmon_update.sh
+  command-working-directory: /opt/webhooks
+  response-message: OK starting mirmon update
+  pass-arguments-to-command:
+    - source: payload
+      name: repository.full_name
+    - source: payload
+      name: head_commit.id
+  trigger-rule:
+    and:
+    - match:
+        type: payload-hash-sha1
+        secret: my-secret
+        parameter:
+          source: header
+          name: X-Hub-Signature
+    - match:
+        type: regex
+        regex: monitoring/mirmon/mariadb_mirror_list
+        parameter:
+          source: payload
+          name: head_commit.modified


### PR DESCRIPTION
Once the webhook is configured on the upstream repo, on every merge, the monitoring/mirmon/mariadb_mirror_list is deployed on mirmon.mariadb.org and mirmon will start immediatelly an update of the status page.

Based on:
- https://github.com/adnanh/webhook
- https://www.digitalocean.com/community/tutorials/deploying-react-applications-with-webhooks-and-slack-on-ubuntu-16-04