### PR TITLE
aix change from downloadSourceTarballAIX -> checkoutUsingGitWorktree

### DIFF
--- a/buildbot.mariadb.org/master.cfg
+++ b/buildbot.mariadb.org/master.cfg
@@ -729,27 +729,6 @@ def downloadSourceTarball():
   done
 """)])
 
-def downloadSourceTarballAIX():
-    return ShellCommand(
-             name="fetch_tarball",
-             description="fetching source tarball",
-             descriptionDone="fetching source tarball...done",
-             haltOnFailure=True,
-             command=["bash", "-xc", util.Interpolate("""
-  d=/mnt/packages/
-  f="%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz"
-  find $d -type f -mtime +2 -delete -ls
-  for i in `seq 1 10`;
-  do
-    if wget -cO "$d$f" "https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:mariadb_version)s.tar.gz"; then
-        break
-    else
-        sleep $i
-    fi
-  done
-""")])
-
-
 # curl fails range-bytes download miserably due to https://github.com/curl/curl/issues/1163
 # what I tried:
 # flock "$d$f" curl --fail -C - -o "$d$f" "https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:mariadb_version)s.tar.gz"
@@ -2981,13 +2960,11 @@ f_eco_mysqljs.addStep(steps.ShellCommand(
 
 ## f_aix
 f_aix = util.BuildFactory()
-f_aix.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
-f_aix.addStep(downloadSourceTarballAIX())
-f_aix.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
+f_aix.addStep(checkoutUsingGitWorktree())
 f_aix.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='6'))]))
 # build steps
 f_aix.addStep(steps.Compile(command=
-    ["sh", "-c", util.Interpolate("export TMPDIR=$HOME/tmp LIBPATH=/opt/freeware/lib/pthread/ppc64:/opt/freeware/lib:/usr/lib && cmake . -DCMAKE_BUILD_TYPE=%(kw:build_type)s -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DCMAKE_AR=/usr/bin/ar -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=%(kw:perf_schema)s -DPLUGIN_SPHINX=NO %(kw:additional_args)s -DWITH_UNIT_TESTS=NO -DPLUGIN_S3=NO -DWITH_MARIABACKUP=NO -DPLUGIN_WSREP_INFO=NO && make -j%(kw:jobs)s package", perf_schema=util.Property('perf_schema', default='YES'), build_type=util.Property('build_type', default='RelWithDebInfo'), jobs=util.Property('jobs', default='3'), c_compiler=util.Property('c_compiler', default='gcc'), cxx_compiler=util.Property('cxx_compiler', default='g++'), additional_args=util.Property('additional_args', default='') )], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
+    ["sh", "-c", util.Interpolate("export TMPDIR=$HOME/tmp LIBPATH=/opt/freeware/lib/pthread/ppc64:/opt/freeware/lib:/usr/lib && cmake /mnt/packages/%(kw:tarbuildnum)s -DCMAKE_BUILD_TYPE=%(kw:build_type)s -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DCMAKE_AR=/usr/bin/ar -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=%(kw:perf_schema)s -DPLUGIN_SPHINX=NO %(kw:additional_args)s -DWITH_UNIT_TESTS=NO -DPLUGIN_S3=NO -DWITH_MARIABACKUP=NO -DPLUGIN_WSREP_INFO=NO && make -j%(kw:jobs)s package", tarbuildnum=util.Property('tarbuildnum', default='current'), perf_schema=util.Property('perf_schema', default='YES'), build_type=util.Property('build_type', default='RelWithDebInfo'), jobs=util.Property('jobs', default='3'), c_compiler=util.Property('c_compiler', default='gcc'), cxx_compiler=util.Property('cxx_compiler', default='g++'), additional_args=util.Property('additional_args', default='') )], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
 
 f_aix.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
     ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --parallel=6")], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))

--- a/buildbot.mariadb.org/utilities.py
+++ b/buildbot.mariadb.org/utilities.py
@@ -27,6 +27,8 @@ def checkoutUsingGitWorktree():
       cd ..
   fi
 
+  rm -rf %(prop:tarbuildnum)s
+  ln -s mariadb-server-$basebranch %(prop:tarbuildnum)s
   cd mariadb-server-$basebranch
   git fetch origin
   git clean -dfx


### PR DESCRIPTION
AIX is out of space. checkoutUsingGitWorktree offers better space
management.

rlimits for memory do need to be raised otherwise:

Preparing worktree (new branch '10.2')
Branch '10.2' set up to track remote branch '10.2' from 'origin'.
error: Out of memory, malloc failed (tried to allocate 31003242 bytes)
fatal: packed object 55c43c5fb953f9c91975c394a3163f27da782db1 (stored in /home/buildbot/packages/mariadb-server/.git/objects/pack/pack-22ed67ad585a042cb03c1aa1206a53ba6cc5c51a.pack) is corrupt