### PR TITLE
Send HTTP requests with MTR results to the Visualizer

### DIFF
--- a/buildbot.mariadb.org/master-private.cfg-sample
+++ b/buildbot.mariadb.org/master-private.cfg-sample
@@ -21,3 +21,6 @@ private["gh_mdbauth"]= {
     "client":"",
     "secret":""
 }
+
+# Token for sending test results to the Visualizer
+private["visualizer_token"] = ""

--- a/buildbot.mariadb.org/master.cfg
+++ b/buildbot.mariadb.org/master.cfg
@@ -32,6 +32,18 @@ exec(open("master-private.cfg").read(), config, { })
 # has a variety to choose from, like IRC bots.
 
 github_status_builders = ["amd64-centos-7", "amd64-debian-10", "amd64-fedora-33", "amd64-ubuntu-2004-clang11"]
+http_status_push_builders= ["amd64-ubuntu-1404", "amd64-ubuntu-1604", "x86-ubuntu-1604", "amd64-ubuntu-1804", "amd64-ubuntu-2004",
+                            "amd64-ubuntu-2004-clang11", "amd64-ubuntu-2004-gcc10", "amd64-ubuntu-2004-icc", "amd64-ubuntu-2010",
+                            "amd64-debian-9", "x86-debian-9", "amd64-debian-10", "amd64-debian-sid", "x86-debian-sid", "amd64-rhel-7",
+                            "amd64-rhel-8", "amd64-fedora-32", "amd64-fedora-33", "amd64-sles-12", "amd64-sles-15", "amd64-centos-7",
+                            "amd64-centos-8", "amd64-opensuse-15", "amd64-opensuse-42", "ppc64le-ubuntu-1604", "ppc64le-ubuntu-1804",
+                            "ppc64le-ubuntu-2004", "ppc64le-ubuntu-2010", "ppc64le-debian-9", "ppc64le-debian-10", "ppc64le-debian-sid",
+                            "ppc64le-ubuntu-1804-clang6", "ppc64le-ubuntu-1804-clang10", "ppc64le-rhel-7", "ppc64le-rhel-8", "ppc64le-centos-7",
+                            "amd64-ubuntu-1804-clang6", "amd64-ubuntu-1804-debug", "amd64-ubuntu-1804-clang10", "aarch64-ubuntu-1604",
+                            "aarch64-ubuntu-1804", "aarch64-ubuntu-2004", "aarch64-ubuntu-2010", "aarch64-fedora-32", "aarch64-fedora-33",
+                            "aarch64-centos-7", "aarch64-centos-8", "aarch64-debian-9", "aarch64-debian-10", "aarch64-debian-sid",
+                            "aarch64-rhel-7", "aarch64-rhel-8", "x86-ubuntu-1804", "amd64-ubuntu-1804-clang10-asan", "amd64-ubuntu-1804-msan",
+                            "amd64-ubuntu-1804-valgrind", "amd64-ubuntu-1804-bigtest"]
 
 c['services'] = []
 context = util.Interpolate("buildbot/%(prop:buildername)s")
@@ -42,6 +54,37 @@ gs = reporters.GitHubStatusPush(token=config["private"]["gh_mdbci"]["access_toke
                                 verbose=True,
                                 builders=github_status_builders)
 c['services'].append(gs)
+
+class HttpStatusPushAfterFinishBuild(reporters.HttpStatusPush):
+
+    # Information about the start of the build is not required
+    def buildStarted(self, key, build):
+        pass
+
+def generate_json(data):
+    info = {}
+    info["product"] = "MariaDBServerCommunity"
+    info["name"] = f"Community-build-{data['properties'].get('tarbuildnum', [0])[0]}"
+    info["platform"] = data['properties'].get('image_full_name', ['unknown'])[0]
+    info["uid"] = data['properties'].get('tarbuildnum', [0])[0]
+    info["mtr"] = "Community-BuildBot-MTR"
+    info["build_type"] = "changes"
+    info["additional_tool"] = data['properties'].get('additional_tool', ['none'])[0]
+    info["branch"] = data['properties'].get('branch', ['unknown'])[0]
+    info["commit"] = data['properties'].get('commit', ['unknown'])[0]
+    info["repo"] = data['properties'].get('repository', ['https://github.com/MariaDB/server'])[0]
+    info["ci_service"] = "Community BuildBot"
+    info["token"] = config["private"]["visualizer_token"]
+    info["file_url"] = f"https://ci.mariadb.org/{info['uid']}/logs/{data['properties'].get('buildername', ['unknown'])[0]}/mtr.xml"
+    return info
+
+http_status_push = HttpStatusPushAfterFinishBuild(serverUrl="https://server-test.mariadb.net/api/upload_xml_by_url",
+											debug=True,
+											format_fn=generate_json,
+											builders=http_status_push_builders,
+											wantProperties=True)
+
+c['services'].append(http_status_push)
 
 ####### PROJECT IDENTITY
 
@@ -772,6 +815,9 @@ for ((mtr=0; mtr<=parallel; mtr++)); do
         if [ -e $filename ]; then
             cp $filename /buildbot/logs/$logname
         fi
+		if [ -e mysql-test/mtr.xml ]; then
+			cp mysql-test/mtr.xml /buildbot/logs/
+		fi
     done
 done
 """
@@ -2577,7 +2623,7 @@ f_quick_build.addStep(steps.Compile(command=
     ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DCMAKE_BUILD_TYPE=%(kw:build_type)s -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=%(kw:perf_schema)s -DPLUGIN_SPHINX=NO %(kw:additional_args)s && make -j%(kw:jobs)s package", perf_schema=util.Property('perf_schema', default='YES'), build_type=util.Property('build_type', default='RelWithDebInfo'), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'), c_compiler=util.Property('c_compiler', default='gcc'), cxx_compiler=util.Property('cxx_compiler', default='g++'), additional_args=util.Property('additional_args', default='') )], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
 
 f_quick_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2) %(kw:mtr_additional_args)s", mtr_additional_args=util.Property('mtr_additional_args', default=''), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
+    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --xml-report=mtr.xml --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2) %(kw:mtr_additional_args)s", mtr_additional_args=util.Property('mtr_additional_args', default=''), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
 f_quick_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
 f_quick_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
 ## trigger packages
@@ -2603,7 +2649,7 @@ f_32b_quick_build.addStep(steps.Compile(command=
     ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DCMAKE_SYSTEM_LIBRARY_PATH=/usr/lib/i386-linux-gnu/ -DCMAKE_LIBRARY_PATH=/usr/lib/i386-linux-gnu/ -DCMAKE_FIND_ROOT_PATH=/usr/lib/i386-linux-gnu -DCMAKE_LIBRARY_ARCHITECTURE=i386 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=g++ -DWITH_EMBEDDED_SERVER=OFF -DWITH_SAFEMALLOC=OFF -DWITH_WSREP=OFF -DPLUGIN_ARCHIVE=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_CONNECT=NO -DPLUGIN_SPHINX=NO -DWITH_SSL=bundled -DWITH_ZLIB=system -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 && make -j%(kw:jobs)s package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)') )], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
 
 f_32b_quick_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
+    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --xml-report=mtr.xml --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
 f_32b_quick_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
 f_32b_quick_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
 # create package and upload to master
@@ -2623,7 +2669,7 @@ f_asan_build.addStep(steps.ShellCommand(command='cat mysql-test/lsan.supp', doSt
 f_asan_build.addStep(steps.Compile(command=
     ["sh", "-c", util.Interpolate('cmake . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-O2 -msse4.2 -Wno-unused-command-line-argument -fdebug-macro -Wno-inconsistent-missing-override" -DCMAKE_CXX_FLAGS="-O2 -msse4.2 -Wno-unused-command-line-argument -fdebug-macro -Wno-inconsistent-missing-override" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DWITH_ASAN=YES -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF -DWITH_ZLIB=bundled -DWITH_SSL=bundled -DWITH_PCRE=system && make -j%(kw:jobs)s package', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], haltOnFailure="true"))
 f_asan_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate('cd mysql-test && MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=`pwd`/lsan.supp" perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
+    ["sh", "-c", util.Interpolate('cd mysql-test && MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=`pwd`/lsan.supp" perl mysql-test-run.pl --xml-report=mtr.xml --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
 f_asan_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
 f_asan_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
 f_asan_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
@@ -2639,7 +2685,7 @@ f_msan_build.addStep(steps.ShellCommand(command='ls /mariadb/llvm-toolchain-10-1
 f_msan_build.addStep(steps.Compile(command=
     ["sh", "-c", util.Interpolate('cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_FLAGS="-O2 -march=native -mtune=native -Wno-unused-command-line-argument -fdebug-macro -Wno-inconsistent-missing-override" -DCMAKE_CXX_FLAGS="-stdlib=libc++ -O2 -march=native -mtune=native -Wno-unused-command-line-argument -fdebug-macro -Wno-inconsistent-missing-override" -DWITH_EMBEDDED_SERVER=OFF -DWITH_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DWITH_INNODB_BZIP2=OFF -DWITH_INNODB_LZ4=OFF -DWITH_INNODB_LZMA=OFF -DWITH_INNODB_LZO=OFF -DWITH_INNODB_SNAPPY=OFF -DPLUGIN_ARCHIVE=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DPLUGIN_SPIDER=NO -DWITH_SAFEMALLOC=OFF -DWITH_ZLIB=bundled -DWITH_SSL=bundled -DWITH_PCRE=bundled -DHAVE_LIBAIO_H=0 -DWITH_MSAN=ON -DWITH_DBUG_TRACE=OFF && make -j%(kw:jobs)s package', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], haltOnFailure="true"))
 f_msan_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate('cd mysql-test && LD_LIBRARY_PATH=/mariadb/llvm-toolchain-10-10.0.1/libc++msan/lib MSAN_OPTIONS=abort_on_error=1 ./mtr --big-test --force --retry=0 --max-test-fail=40 --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
+    ["sh", "-c", util.Interpolate('cd mysql-test && LD_LIBRARY_PATH=/mariadb/llvm-toolchain-10-10.0.1/libc++msan/lib MSAN_OPTIONS=abort_on_error=1 ./mtr --xml-report=mtr.xml --big-test --force --retry=0 --max-test-fail=40 --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
 f_msan_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
 f_msan_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
 f_msan_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
@@ -2654,7 +2700,7 @@ f_valgrind_build.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf 
 f_valgrind_build.addStep(steps.Compile(command=
     ["sh", "-c", util.Interpolate('cmake . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DENABLE_ASSEMBLER=1 -DWITH_EXTRA_CHARSETS=complex -DENABLE_THREAD_SAFE_CLIENT=1 -DWITH_BIG_TABLES=1 -DWITH_PLUGIN_ARIA=1 -DWITH_ARIA_TMP_TABLES=1 -DWITH_JEMALLOC=NO=1 -DCMAKE_BUILD_TYPE=Debug -DSECURITY_HARDENED=OFF -DWITH_VALGRIND=1 -DWITH_SSL=bundled -DWITH_MAX=AUTO -DWITH_EMBEDDED_SERVER=1 -DWITH_LIBEVENT=bundled -DPLUGIN_PLUGIN_FILE_KEY_MANAGEMENT=NO -DPLUGIN_ROCKSDB=DYNAMIC -DPLUGIN_TEST_SQL_DISCOVERY=DYNAMIC -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DENABLE_LOCAL_INFILE=1 && make -j%(kw:jobs)s package', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], haltOnFailure="true"))
 f_valgrind_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate('cd mysql-test && perl mysql-test-run.pl --valgrind-mysqld --valgrind-option=--leak-check=summary --valgrind-option=--gen-suppressions=all --valgrind-option=--num-callers=10 --skip-test=encryption*  --force --retry=0 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
+    ["sh", "-c", util.Interpolate('cd mysql-test && perl mysql-test-run.pl --xml-report=mtr.xml --valgrind-mysqld --valgrind-option=--leak-check=summary --valgrind-option=--gen-suppressions=all --valgrind-option=--num-callers=10 --skip-test=encryption*  --force --retry=0 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
 f_valgrind_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
 f_valgrind_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
 f_valgrind_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
@@ -2671,7 +2717,7 @@ f_big_test.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf " + "%
 f_big_test.addStep(steps.Compile(command=
     ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPLUGIN_ROCKSDB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_SPHINX=NO && make -j%(kw:jobs)s VERBOSE=1 package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], env={'CCACHE_DIR':'/mnt/ccache'}))
 f_big_test.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --big --big --mem --parallel=$(expr %(kw:jobs)s \* 2) --skip-test=archive.archive-big", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
+    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --xml-report=mtr.xml --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --big --big --mem --parallel=$(expr %(kw:jobs)s \* 2) --skip-test=archive.archive-big", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
 f_big_test.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
 f_big_test.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
 # create package and upload to master
@@ -2990,7 +3036,7 @@ f_aix.addStep(steps.Compile(command=
     ["sh", "-c", util.Interpolate("export TMPDIR=$HOME/tmp LIBPATH=/opt/freeware/lib/pthread/ppc64:/opt/freeware/lib:/usr/lib && cmake . -DCMAKE_BUILD_TYPE=%(kw:build_type)s -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DCMAKE_AR=/usr/bin/ar -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=%(kw:perf_schema)s -DPLUGIN_SPHINX=NO %(kw:additional_args)s -DWITH_UNIT_TESTS=NO -DPLUGIN_S3=NO -DWITH_MARIABACKUP=NO -DPLUGIN_WSREP_INFO=NO && make -j%(kw:jobs)s package", perf_schema=util.Property('perf_schema', default='YES'), build_type=util.Property('build_type', default='RelWithDebInfo'), jobs=util.Property('jobs', default='3'), c_compiler=util.Property('c_compiler', default='gcc'), cxx_compiler=util.Property('cxx_compiler', default='g++'), additional_args=util.Property('additional_args', default='') )], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
 
 f_aix.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --parallel=6")], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
+    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --parallel=6")], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, autoCreateTables=True))
 f_aix.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='6'))]))
 f_aix.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
 f_aix.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
@@ -3100,6 +3146,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_trusty"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3120,6 +3167,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_xenial"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3140,6 +3188,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_xenial"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3160,6 +3209,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_bionic"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3210,6 +3260,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_focal"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3220,7 +3271,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'c_compiler': 'clang-11', 'cxx_compiler': 'clang++', 'mtr_additional_args': protected_branches_mtr_additional_args},
+      properties={'c_compiler': 'clang-11', 'cxx_compiler': 'clang++', 'mtr_additional_args': protected_branches_mtr_additional_args, "image_full_name": "ubuntu_focal"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3231,7 +3282,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'c_compiler': 'gcc-10', 'cxx_compiler': 'g++-10'},
+      properties={'c_compiler': 'gcc-10', 'cxx_compiler': 'g++-10', "image_full_name": "ubuntu_focal"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3242,7 +3293,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'c_compiler': 'icc', 'cxx_compiler': 'icpc'},
+      properties={'c_compiler': 'icc', 'cxx_compiler': 'icpc', "image_full_name": "ubuntu_focal"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3263,6 +3314,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_focal"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3318,6 +3370,7 @@ c['builders'].append(
       collapseRequests=True,
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
+      properties={"image_full_name": "ubuntu_bionic"},
       factory=f_big_test))
 
 c['builders'].append(
@@ -3328,6 +3381,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "debian_stretch"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3348,6 +3402,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "debian_stretch"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3368,7 +3423,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
+      properties={'mtr_additional_args': protected_branches_mtr_additional_args, "image_full_name": "debian_buster"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3389,6 +3444,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "debian_sid"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3409,6 +3465,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "debian_sid"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3429,6 +3486,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "rhel_7"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3450,6 +3508,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "rhel_8"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3471,6 +3530,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "fedora_32"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3492,7 +3552,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
+      properties={'mtr_additional_args': protected_branches_mtr_additional_args, "image_full_name": "fedora_33"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3514,6 +3574,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "sles_12"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3535,6 +3596,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "sles_15"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3556,7 +3618,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
+      properties={'mtr_additional_args': protected_branches_mtr_additional_args, "image_full_name": "centos_7"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3609,6 +3671,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "centos_8"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3630,6 +3693,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "suse_15"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3651,6 +3715,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "suse_42"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3682,6 +3747,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_xenial"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3702,6 +3768,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_bionic"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3722,6 +3789,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_focal"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3742,6 +3810,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_focal"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3762,6 +3831,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "debian_stretch"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3782,6 +3852,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "debian_buster"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3802,6 +3873,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "debian_sid"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3832,7 +3904,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'c_compiler': 'clang-6.0', 'cxx_compiler': 'clang++-6.0', 'additional_args': '-DWITHOUT_ROCKSDB=True -DWITHOUT_CONNECT=True -DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override'},
+      properties={'c_compiler': 'clang-6.0', 'cxx_compiler': 'clang++-6.0', 'additional_args': '-DWITHOUT_ROCKSDB=True -DWITHOUT_CONNECT=True -DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override', "image_full_name": "ubuntu_bionic"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3843,7 +3915,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'c_compiler': 'clang-10', 'cxx_compiler': 'clang++', 'additional_args': '-DWITHOUT_ROCKSDB=True -DWITHOUT_CONNECT=True -DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override'},
+      properties={'c_compiler': 'clang-10', 'cxx_compiler': 'clang++', 'additional_args': '-DWITHOUT_ROCKSDB=True -DWITHOUT_CONNECT=True -DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override', "image_full_name": "ubuntu_bionic"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3854,6 +3926,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "rhel_7"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3875,7 +3948,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
+      properties={'mtr_additional_args': protected_branches_mtr_additional_args, "image_full_name": "rhel_8"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3897,6 +3970,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "centos_7"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3918,7 +3992,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'c_compiler': 'clang-6.0', 'cxx_compiler': 'clang++-6.0', 'additional_args': '-DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override'},
+      properties={'c_compiler': 'clang-6.0', 'cxx_compiler': 'clang++-6.0', 'additional_args': '-DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override', "image_full_name": "ubuntu_bionic"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3929,7 +4003,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'build_type': 'Debug'},
+      properties={'build_type': 'Debug', "image_full_name": "ubuntu_bionic"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3940,7 +4014,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'c_compiler': 'clang-10', 'cxx_compiler': 'clang++', 'additional_args': '-DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override'},
+      properties={'c_compiler': 'clang-10', 'cxx_compiler': 'clang++', 'additional_args': '-DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override', "image_full_name": "ubuntu_bionic"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -3951,6 +4025,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_bionic", "additional_tool": "asan"},
       factory=f_asan_build))
 
 c['builders'].append(
@@ -3961,6 +4036,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_bionic", "additional_tool": "msan"},
       factory=f_msan_build))
 
 c['builders'].append(
@@ -3971,6 +4047,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_bionic"},
       factory=f_32b_quick_build))
 
 c['builders'].append(
@@ -3981,6 +4058,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_xenial", "additional_tool": "valgrind"},
       factory=f_valgrind_build))
 
 c['builders'].append(
@@ -3991,6 +4069,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_xenial"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4011,6 +4090,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_bionic"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4031,6 +4111,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_focal"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4051,6 +4132,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "ubuntu_focal"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4071,6 +4153,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "fedora_32"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4092,6 +4175,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "fedora_33"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4113,6 +4197,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "centos_7"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4134,6 +4219,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "centos_8"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4155,6 +4241,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "debian_stretch"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4175,7 +4262,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
+      properties={'mtr_additional_args': protected_branches_mtr_additional_args, "image_full_name": "debian_buster"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4196,6 +4283,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "debian_sid"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4216,6 +4304,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "rhel_7"},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -4237,6 +4326,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
+      properties={"image_full_name": "rhel_8"},
       factory=f_quick_build))
 
 c['builders'].append(


### PR DESCRIPTION
These changes allow send the results of running builds with MTR to the [Visualizer](https://server-test.mariadb.net/) using [HttpStatusPush](https://docs.buildbot.net/2.7.0/manual/configuration/reporters.html#httpstatuspush)