### PR TITLE
serg/mtr-bash-completion enhancement

### DIFF
--- a/serg/mtr-bash-completion.sh
+++ b/serg/mtr-bash-completion.sh
@@ -1,30 +1,30 @@
 _mtr_complete_testnames ()
 {
-  dir=$1
-  [ -d $dir/t ] && dir=$dir/t
-  testnames=$( cd $dir && echo *.test | sed -e 's/\.test\>//g' )
+  dir="$1"
+  [ -d "$dir"/t ] && dir="$dir"/t
+  testnames=$( cd "$dir" && echo *.test | sed -e 's/\.test\>//g' )
 }
 _mtr_all_suites ()
 {
-  suites=$(find suite ../{storage,plugin}/*/mysql-test -type d -exec find '{}' -maxdepth 1  -name '*.test' -print -quit \; | sed -E 's@/(t/)?[^/]+$@@; s@^(suite|.*/mysql-test)/@@'|sort -u)
+  suites=$(find "$sourcetestdir"/suite "$sourcetestdir"/../{storage,plugin}/*/mysql-test -type d -exec find '{}' -maxdepth 1  -name '*.test' -print -quit \; | sed -E "s@^$sourcetestdir/(suite|\.\./storage|\.\./plugin)/@@"'; s@/mysql-test@@; s@(/t)?/[^/]+\.test$@@'|sort -u)
 }
 _mtr_complete()
 {
-  [ -x ./mtr ] || return
-  [ -d main ] && main=main || main=.
+  sourcetestdir=$(sed -n -e "/^chdir/s/[^']*'\(.*\)');$/\1/p" < "$1")
   cur=$2
   prev=$3
   case $prev:$cur in
     *:--*)
-      opts=$( ./mtr --list )
+      opts=$( "$1" --list )
       COMPREPLY=( $( compgen -W "$opts" -- $cur) )
       ;;
     *:main.*)
-      _mtr_complete_testnames $main
+      [ -d "${sourcetestdir}/main" ] && dir="${sourcetestdir}/main" || dir="${sourcetestdir}"
+      _mtr_complete_testnames "$dir"
       COMPREPLY=( $( compgen -P ${cur%.*}. -W "$testnames" -- ${cur#*.}) )
       ;;
     *:?*.*)
-      for dir in {../{storage,plugin}/*/mysql-test,suite}/${cur%.*}; do
+      for dir in "${sourcetestdir}"/{suite,../{storage,plugin}/*/mysql-test}/${cur%.*}; do
         if [ -d $dir ]; then
           _mtr_complete_testnames $dir
           break


### PR DESCRIPTION
Handle out of tree builds

Handle mysql-test/mtr completions where mtr isn't the current directory

Order "suite" before "storage,plugins" _mtr_complete_testnames so that
"rpl" picks up rpl suite rather than the tokudb rpl suite.