### PR TITLE
bb.org: wsrep_provider is read-only

### DIFF
--- a/buildbot.mariadb.org/master.cfg
+++ b/buildbot.mariadb.org/master.cfg
@@ -1412,10 +1412,11 @@ gpgcheck=1' > /etc/yum.repos.d/galera.repo"
 		  esac
 		  sudo cat /etc/yum.repos.d/galera.repo
 		  sudo yum -y --nogpgcheck install rpms/*.rpm
+		  sudo sh -c 'g=/usr/lib*/galera*/libgalera_smm.so; echo -e "[galera]\nwsrep_provider=$g"' > /etc/my.cnf.d/galera.cnf
 		  case "%(prop:systemdCapability)s" in
 		  yes)
 		    if ! sudo systemctl start mariadb ; then
-		      sudo journalctl -lxn 500 --no-pager | grep -iE 'mysqld|mariadb'
+		      sudo journalctl -lxn 500 --no-pager -u mariadb.service
 		      sudo systemctl -l status mariadb.service --no-pager
 		      exit 1
 		    fi
@@ -1442,32 +1443,7 @@ gpgcheck=1' > /etc/yum.repos.d/galera.repo"
 		    sudo systemctl restart mariadb-columnstore
 		    mysql --verbose -uroot -e "update cs.t_columnstore set a = a + 10; select * from cs.t_columnstore"
 		  fi
-		# Check if the build is WSREP-aware. It might be not, if it was built
-		# with WITH_WSREP=OFF
-		  if sudo mysqld --help --verbose 2>&1 | grep wsrep > /dev/null ; then
-		    galera_path=`echo /usr/lib*/galera*/libgalera_smm.so`
-		    # Half-initialization of galera makes further shutdown hang, removed set global wsrep_cluster_address="gcomm://"
-		    mysql -uroot -e 'set global wsrep_provider="'$galera_path'"; show status like "wsrep%%"'
-		  fi
-		  ;;
-		# 5.5-galera, 10.0-galera and alike
-		*galera*)
-		  sudo sh -c "echo '[galera]
-		name=galera
-		baseurl=http://yum.mariadb.org/galera/repo/rpm/%(prop:arch)s"
-		gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-		gpgcheck=1' > /etc/yum.repos.d/galera.repo"
-		  sudo cat /etc/yum.repos.d/galera.repo
-		  sudo sh -c "echo '[mariadb]
-		name=MariaDB
-		baseurl=http://yum.mariadb.org/$(cat /tmp/VERSION)/%(prop:arch)s"
-		gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-		gpgcheck=1' > /etc/yum.repos.d/MariaDB.repo"
-		  sudo cat /etc/yum.repos.d/MariaDB.repo
-		  sudo yum -y --nogpgcheck install rpms/*.rpm
-		  sudo /etc/init.d/mysql restart
-		  galera_path=`echo /usr/lib*/galera*/libgalera_smm.so`
-		  mysql -uroot -e 'use test; create table t(a int primary key) engine=innodb; insert into t values (1); select * from t; drop table t;set global wsrep_provider="'$galera_path'"; set global wsrep_cluster_address="gcomm://";show status like "wsrep%%"'
+		  mysql -uroot -e 'show global status like "wsrep%%"'
 		  ;;
 		# 5.5/10.0 non-Galera branches
 		*)


### PR DESCRIPTION
From failure: https://buildbot.mariadb.org/#/builders/198/builds/704/steps/2/logs/stdio

Don't error like:

+ galera_path=/usr/lib64/galera-4/libgalera_smm.so
+ mysql -uroot -e 'set global wsrep_provider="/usr/lib64/galera-4/libgalera_smm.so"; show status like "wsrep%"'
ERROR 1238 (HY000) at line 1: Variable 'wsrep_provider' is a read only variable
program finished with exit code 1

MariaDB won't read a [galera] section if not enabled. Following
instructions start the galera service.

Use journalctl to show the mariadb.service only

Remove old 5.5-galera, 10.0-galera code