### PR TITLE
bb.org: jemalloc-devel for rpm builders for 10.2-10.4 tokudb

### DIFF
--- a/buildbot.mariadb.org/dockerfiles/centos-7.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/centos-7.dockerfile
@@ -49,7 +49,7 @@ RUN alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 \
 --family cmake
 
 RUN yum -y install cracklib cracklib-dicts cracklib-devel boost-devel curl-devel libxml2-devel lz4-devel snappy-devel check-devel scons
-RUN yum -y install which Judy-devel binutils bison boost-devel checkpolicy coreutils cracklib-devel flex gawk gcc gcc-c++ git glibc-common glibc-devel groff-base java-1.8.0-openjdk-devel java-1.8.0-openjdk java-1.8.0-openjdk-headless krb5-devel libaio-devel libcurl-devel libevent-devel libxml2 libxml2-devel libzstd-devel make ncurses-devel openssl-devel pam-devel pcre2-devel pkgconfig policycoreutils-python readline-devel ruby snappy-devel systemd-devel systemtap-sdt-devel tar unixODBC unixODBC-devel xz-devel zlib-devel which
+RUN yum -y install which Judy-devel binutils bison boost-devel checkpolicy coreutils cracklib-devel flex gawk gcc gcc-c++ git glibc-common glibc-devel groff-base java-1.8.0-openjdk-devel java-1.8.0-openjdk java-1.8.0-openjdk-headless krb5-devel libaio-devel libcurl-devel libevent-devel libxml2 libxml2-devel libzstd-devel make ncurses-devel openssl-devel pam-devel pcre2-devel pkgconfig policycoreutils-python readline-devel ruby snappy-devel systemd-devel systemtap-sdt-devel tar unixODBC unixODBC-devel xz-devel zlib-devel which jemalloc-devel
 
 USER buildbot
 CMD ["/usr/local/bin/dumb-init", "twistd", "--pidfile=", "-ny", "buildbot.tac"]

--- a/buildbot.mariadb.org/dockerfiles/fedora-33.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/fedora-33.dockerfile
@@ -35,10 +35,10 @@ RUN pip install buildbot-worker && \
 RUN curl -Lo /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 && \
     chmod +x /usr/local/bin/dumb-init
 
-RUN dnf -y install cracklib cracklib-dicts cracklib-devel boost-devel curl-devel libxml2-devel lz4-devel snappy-devel check-devel scons
-RUN dnf -y install flex readline-devel
-RUN dnf -y install Judy-devel binutils bison boost-devel checkpolicy coreutils cracklib-devel flex gawk gcc gcc-c++ git-core glibc-common glibc-devel groff-base java-latest-openjdk-devel java-latest-openjdk java-latest-openjdk-headless krb5-devel libaio-devel libcurl-devel libedit-devel libevent-devel libxcrypt-devel libxml2 libxml2-devel libzstd-devel lz4-devel make ncurses-devel openssl-devel pam-devel pcre2-devel pkgconf-pkg-config policycoreutils readline-devel rubypick snappy-devel systemd-devel systemtap-sdt-devel tar unixODBC unixODBC-devel xz-devel zlib-devel which python
-RUN dnf -y install liburing-devel libpmem-devel
+RUN dnf -y install cracklib cracklib-dicts cracklib-devel boost-devel curl-devel libxml2-devel lz4-devel snappy-devel check-devel scons \
+    flex readline-devel \
+    Judy-devel binutils bison boost-devel checkpolicy coreutils cracklib-devel flex gawk gcc gcc-c++ git-core glibc-common glibc-devel groff-base java-latest-openjdk-devel java-latest-openjdk java-latest-openjdk-headless krb5-devel libaio-devel libcurl-devel libedit-devel libevent-devel libxcrypt-devel libxml2 libxml2-devel libzstd-devel lz4-devel make ncurses-devel openssl-devel pam-devel pcre2-devel pkgconf-pkg-config policycoreutils readline-devel rubypick snappy-devel systemd-devel systemtap-sdt-devel tar unixODBC unixODBC-devel xz-devel zlib-devel which python \
+    liburing-devel libpmem-devel gdb jemalloc-devel && dnf clean all
 
 USER buildbot
 CMD ["/usr/local/bin/dumb-init", "twistd", "--pidfile=", "-ny", "buildbot.tac"]

--- a/buildbot.mariadb.org/dockerfiles/fedora-34.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/fedora-34.dockerfile
@@ -36,9 +36,9 @@ RUN curl -Lo /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases
     chmod +x /usr/local/bin/dumb-init
 
 RUN dnf -y install cracklib cracklib-dicts cracklib-devel boost-devel curl-devel libxml2-devel lz4-devel snappy-devel check-devel scons
-RUN dnf -y install flex readline-devel
-RUN dnf -y install Judy-devel binutils bison boost-devel checkpolicy coreutils cracklib-devel flex gawk gcc gcc-c++ git-core glibc-common glibc-devel groff-base java-latest-openjdk-devel java-latest-openjdk java-latest-openjdk-headless krb5-devel libaio-devel libcurl-devel libedit-devel libevent-devel libxcrypt-devel libxml2 libxml2-devel libzstd-devel lz4-devel make ncurses-devel openssl-devel pam-devel pcre2-devel pkgconf-pkg-config policycoreutils readline-devel rubypick snappy-devel systemd-devel systemtap-sdt-devel tar unixODBC unixODBC-devel xz-devel zlib-devel which python
-RUN dnf -y install liburing-devel libpmem-devel gdb
+    flex readline-devel \
+    Judy-devel binutils bison boost-devel checkpolicy coreutils cracklib-devel flex gawk gcc gcc-c++ git-core glibc-common glibc-devel groff-base java-latest-openjdk-devel java-latest-openjdk java-latest-openjdk-headless krb5-devel libaio-devel libcurl-devel libedit-devel libevent-devel libxcrypt-devel libxml2 libxml2-devel libzstd-devel lz4-devel make ncurses-devel openssl-devel pam-devel pcre2-devel pkgconf-pkg-config policycoreutils readline-devel rubypick snappy-devel systemd-devel systemtap-sdt-devel tar unixODBC unixODBC-devel xz-devel zlib-devel which python \
+    liburing-devel libpmem-devel gdb jemalloc-devel && dnf clean all
 
 USER buildbot
 CMD ["/usr/local/bin/dumb-init", "twistd", "--pidfile=", "-ny", "buildbot.tac"]

--- a/buildbot.mariadb.org/dockerfiles/rhel-8.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/rhel-8.dockerfile
@@ -44,8 +44,11 @@ RUN pip3 install -U pip virtualenv && \
 # so we need to simulate that here.  See https://github.com/Yelp/dumb-init
 RUN curl -Lo /tmp/dumb.rpm https://cbs.centos.org/kojifiles/packages/dumb-init/1.2.2/6.el8/$(arch)/dumb-init-1.2.2-6.el8.$(arch).rpm && yum -y localinstall /tmp/dumb.rpm
 
-RUN yum -y install cracklib cracklib-dicts cracklib-devel boost-devel curl-devel libxml2-devel lz4-devel snappy-devel check-devel python3-scons
-RUN yum -y install Judy-devel binutils bison boost-devel checkpolicy coreutils cracklib-devel gcc gcc-c++ git glibc-common glibc-devel groff-base java-1.8.0-openjdk java-1.8.0-openjdk-headless krb5-devel libaio-devel libcurl-devel libevent-devel libxml2 libxml2-devel libzstd-devel make ncurses-devel openssl-devel pam-devel pcre2-devel pkgconfig policycoreutils readline-devel ruby snappy-devel systemd-devel systemtap-sdt-devel tar unixODBC unixODBC-devel xz-devel zlib-devel which python3 --allowerasing
+RUN dnf -y install cracklib cracklib-dicts cracklib-devel boost-devel curl-devel libxml2-devel lz4-devel snappy-devel check-devel python3-scons \
+    judy-devel binutils bison boost-devel checkpolicy coreutils cracklib-devel gcc gcc-c++ git glibc-common glibc-devel groff-base java-1.8.0-openjdk \
+    java-1.8.0-openjdk-headless krb5-devel libaio-devel libcurl-devel libevent-devel libxml2 libxml2-devel libzstd-devel make ncurses-devel \
+    openssl-devel pam-devel pcre2-devel pkgconfig policycoreutils readline-devel ruby snappy-devel systemd-devel systemtap-sdt-devel tar unixODBC \
+    unixODBC-devel xz-devel zlib-devel which python3 gdb jemalloc-devel --allowerasing && dnf clean all
 
 RUN subscription-manager unregister
 

--- a/buildbot.mariadb.org/dockerfiles/sles-15.dockerfile
+++ b/buildbot.mariadb.org/dockerfiles/sles-15.dockerfile
@@ -51,7 +51,7 @@ RUN curl -Lo /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases
 
 RUN zypper install -y policycoreutils rpm-build
 
-RUN zypper install -y boost-devel libcurl-devel cracklib-devel libxml2-devel snappy-devel scons check-devel liblz4-devel
+RUN zypper install -y boost-devel libcurl-devel cracklib-devel libxml2-devel snappy-devel scons check-devel liblz4-devel jemalloc-devel
 
 USER buildbot
 CMD ["/usr/local/bin/dumb-init", "twistd", "--pidfile=", "-ny", "buildbot.tac"]


### PR DESCRIPTION
provided by epel. needed amd64 only

sles-15 verified by https://distrowatch.com/table.php?distribution=sle&pkglist=true&version=15-sp2 and it not being on the mirror https://archive.mariadb.org/mariadb-10.4.20/yum/sles15-amd64/rpms/.
