### PR TITLE
bb.org: Add docker library cleanup on dependent failure

### DIFF
--- a/buildbot.mariadb.org/master.cfg
+++ b/buildbot.mariadb.org/master.cfg
@@ -7,6 +7,7 @@ from buildbot.steps.shell import ShellCommand, Compile, Test, SetPropertyFromCom
 from buildbot.steps.mtrlogobserver import MTR, MtrLogObserver
 from buildbot.steps.source.github import GitHub
 from buildbot.process.remotecommand import RemoteCommand
+from buildbot.process.results import FAILURE, EXCEPTION, CANCELLED
 from twisted.internet import defer
 import sys
 import docker
@@ -263,6 +264,10 @@ c['schedulers'].append(schedulerEco)
 schedulerDockerlibrary = schedulers.Triggerable(name="s_dockerlibrary",
         builderNames=getDockerLibraryNames)
 c['schedulers'].append(schedulerDockerlibrary)
+
+schedulerDockerlibraryCleanup = schedulers.Triggerable(name="s_dockerlibrary_cleanup",
+        builderNames=getDockerLibraryNames)
+c['schedulers'].append(schedulerDockerlibraryCleanup)
 
 ####### WORKERS
 
@@ -1175,6 +1180,8 @@ f_deb_autobake.addStep(steps.Trigger(name='major-minor-upgrade', schedulerNames=
     set_properties={"tarbuildnum" : Property("tarbuildnum"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch"), "parentbuildername": Property("buildername")}, doStepIf=lambda step: hasUpgrade(step) and savePackage(step) and hasFiles(step)))
 f_deb_autobake.addStep(steps.Trigger(name='dockerlibrary', schedulerNames=['s_dockerlibrary'], waitForFinish=False, updateSourceStamp=False,
     set_properties={"tarbuildnum" : Property("tarbuildnum"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch"), "parentbuildername": Property("buildername")}, doStepIf=lambda step: savePackage(step) and hasDockerLibrary(step)))
+f_deb_autobake.addStep(steps.Trigger(name='dockerlibrary-fail-cleanup', schedulerNames=['s_dockerlibrary_cleanup'], waitForFinish=False, updateSourceStamp=False,
+    set_properties={"mariadb_version" : Property("mariadb_version"), "parentbuildername": Property("buildername")}, doStepIf=lambda step: savePackage(step) and hasDockerLibrary(step) and step.results in (FAILURE, CANCELLED, EXCEPTION), alwaysRun=True)
 f_deb_autobake.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_deb_install
@@ -1451,6 +1458,12 @@ f_dockerlibrary.addStep(steps.ShellCommand(
 f_dockerlibrary.addStep(steps.ShellCommand(
     name="building and test docker library image for MariaDB",
     command=["bash", "-xc", util.Interpolate("./docker-library-build-and-test.sh \"%(prop:tarbuildnum)s\" \"%(prop:mariadb_version)s\" \"%(prop:parentbuildername)s\" \"%(prop:revision)s\" \"%(prop:branch)s\"")]))
+
+f_dockerlibrary_cleanup = util.BuildFactory()
+f_dockerlibrary_cleanup.addStep(getScript('docker_cleanup.sh'))
+f_dockerlibrary_cleanup.addStep(steps.ShellCommand(
+    name="cleanup manifest/images because one dependency failed to build",
+    command=["bash", "-xc", util.Interpolate("./docker_cleanup.sh \"%(prop:mariadb_version)s\" \"%(prop:revision)s\" \"%(prop:branch)s\"")]))
 
 ## f_aix
 f_aix = util.BuildFactory()
@@ -1772,6 +1785,15 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       factory=f_dockerlibrary))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-rhel8-dockerlibrary-cleanup",
+      workernames=["bb-rhel8-docker"],
+      tags=["RHEL"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      factory=f_dockerlibrary_cleanup))
 
 c['builders'].append(
     util.BuilderConfig(name="amd64-ubuntu-1804-bigtest",

--- a/buildbot.mariadb.org/scripts/docker_cleanup.sh
+++ b/buildbot.mariadb.org/scripts/docker_cleanup.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -xeuvo pipefail
+
+mariadb_version=${1}
+mariadb_version=${mariadb_version#*-}
+master_branch=${mariadb_version%\.*}
+
+commit=${2:-}
+branch=${3:-${master_branch}}
+
+if [[ $branch =~ ^preview ]]; then
+  container_tag=${branch#preview-[0-9]*\.[0-9]*-}
+else
+  container_tag=$master_branch
+fi
+# Container tags must be lower case.
+container_tag=${container_tag,,*}
+
+t=$(mktemp)
+for m in mariadb-devel-${container_tag}-$commit mariadb-debug-${container_tag}-$commit
+do
+  echo cleanup $m
+  buildah manifest inspect "$m" | jq '.manifests[]?.digest?' | tee -a "$t"
+done
+
+podman images --filter dangling=true --format '{{.ID}} {{.Digest}}' |
+while read line; do
+  id="${line% *}"
+  digest="${line#* }"
+  echo "id=$id digest=$digest"
+  if grep "$digest" "$t"
+  then
+    echo -e "\nRemove image:"
+    podman rmi "$id"
+    echo
+  fi
+done
+
+rm "$t"
+for m in mariadb-devel-${container_tag}-$commit mariadb-debug-${container_tag}-$commit
+do
+  echo cleanup $m
+  buildah manifest rm "$m"
+done


### PR DESCRIPTION
results appears to be BuildStep attribute per
master/buildbot/process/buildstep.py in the buildbot code.

The unused(broken?) ifStagingSucceeding uses:
  step.build.results in ('SUCCESS', 'WARNINGS')