### PR TITLE
Using a default base image is not recommended

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -98,6 +98,10 @@ jobs:
       - name: Set up env vars
         run: |
           set -vx
+          [[ -n "${{ matrix.image }}" ]] || {
+            echo "Missing base image (FROM)"
+            exit 1
+          }
           TAG_TMP=${{ matrix.image }}
           if [[ $TAG_TMP = "ubi8" ]]; then
             echo "TAG=rhel8" >>$GITHUB_ENV

--- a/buildbot.mariadb.org/ci_build_images/centos.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/centos.Dockerfile
@@ -3,7 +3,7 @@
 # Provides a base CentOS image with latest buildbot worker installed
 # and MariaDB build dependencies
 
-ARG base_image=centos:8
+ARG base_image
 FROM "$base_image"
 LABEL maintainer="MariaDB Buildbot maintainers"
 

--- a/buildbot.mariadb.org/ci_build_images/centos7.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/centos7.Dockerfile
@@ -3,7 +3,7 @@
 # Provides a base CentOS image with latest buildbot worker installed
 # and MariaDB build dependencies
 
-ARG base_image=centos:7
+ARG base_image
 FROM "$base_image"
 LABEL maintainer="MariaDB Buildbot maintainers"
 

--- a/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
@@ -3,7 +3,7 @@
 # Provides a base Debian/Ubuntu image with latest buildbot worker installed
 # and MariaDB build dependencies
 
-ARG base_image=debian:11
+ARG base_image
 FROM "$base_image"
 ARG mariadb_branch=10.5
 LABEL maintainer="MariaDB Buildbot maintainers"

--- a/buildbot.mariadb.org/ci_build_images/fedora.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/fedora.Dockerfile
@@ -3,7 +3,7 @@
 # Provides a base Fedora image with latest buildbot worker installed
 # and MariaDB build dependencies
 
-ARG base_image=fedora:34
+ARG base_image
 FROM "$base_image"
 LABEL maintainer="MariaDB Buildbot maintainers"
 

--- a/buildbot.mariadb.org/ci_build_images/rhel7.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/rhel7.Dockerfile
@@ -3,7 +3,7 @@
 # Provides a base RHEL-7 image with latest buildbot worker installed
 # and MariaDB build dependencies
 
-ARG base_image=rhel7
+ARG base_image
 FROM registry.access.redhat.com/$base_image
 LABEL maintainer="MariaDB Buildbot maintainers"
 

--- a/buildbot.mariadb.org/ci_build_images/rhel8.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/rhel8.Dockerfile
@@ -3,7 +3,7 @@
 # Provides a base RHEL-8 image with latest buildbot worker installed
 # and MariaDB build dependencies
 
-ARG base_image=ubi8
+ARG base_image
 FROM registry.access.redhat.com/$base_image
 LABEL maintainer="MariaDB Buildbot maintainers"
 


### PR DESCRIPTION
The last thing we want is for us to have a typo in the CI yml and have
fedora:34 images when we think we should have fedora 35 and everything
be green.