### PR TITLE
bb: produce debian repo compatible file structure

### DIFF
--- a/buildbot.mariadb.org/master-galera/master.cfg
+++ b/buildbot.mariadb.org/master-galera/master.cfg
@@ -284,13 +284,11 @@ def dpkgDeb():
             name="dpkg-scanpackages/sources",
             haltOnFailure=True,
             command=["sh", "-xc", util.Interpolate("""set -e
-    mkdir -p debs/binary debs/source
-    find .. -maxdepth 1 -type f \( -name \*.deb -o -name \*.ddeb \) -exec cp {} debs/binary/ \;
-    find .. -maxdepth 1 -type f \( -name \*.dsc -o -name \*.*z \) -exec cp {} debs/source/ \;
-    mv ../*buildinfo ../*changes debs/
+    mkdir -p debs
+    find .. -maxdepth 1 -type f -exec cp {} debs/ \;
     cd debs
-    ( dpkg-scanpackages binary /dev/null && dpkg-scanpackages --type ddeb binary /dev/null  )| gzip -9c > Packages.gz
-    dpkg-scansources source /dev/null | gzip -9c > Sources.gz
+    ( dpkg-scanpackages . /dev/null && dpkg-scanpackages --type ddeb . /dev/null  )| gzip -9c > Packages.gz
+    dpkg-scansources . /dev/null | gzip -9c > Sources.gz
     cd ..
     find debs -type f -exec sha256sum {} \; | sort > sha256sums.txt
 """)], doStepIf=lambda step: savePackage(step))

--- a/buildbot.mariadb.org/master.cfg
+++ b/buildbot.mariadb.org/master.cfg
@@ -491,13 +491,11 @@ def dpkgDeb():
             name="dpkg-scanpackages/sources",
             haltOnFailure=True,
             command=["sh", "-xc", util.Interpolate("""
-    mkdir -p debs/binary debs/source
-    find .. -maxdepth 1 -type f \( -name \*.deb -o -name \*.ddeb \) -exec cp {} debs/binary/ \;
-    find .. -maxdepth 1 -type f \( -name \*.dsc -o -name \*.*z \) -exec cp {} debs/source/ \;
-    mv ../*buildinfo ../*changes debs/
+    mkdir -p debs/
+    find .. -maxdepth 1 -type f -exec cp {} debs/ \;
     cd debs
-    ( dpkg-scanpackages binary /dev/null && dpkg-scanpackages --type ddeb binary /dev/null  )| gzip -9c > Packages.gz
-    dpkg-scansources source /dev/null | gzip -9c > Sources.gz
+    ( dpkg-scanpackages . /dev/null && dpkg-scanpackages --type ddeb . /dev/null  )| gzip -9c > Packages.gz
+    dpkg-scansources . /dev/null | gzip -9c > Sources.gz
     cd ..
     find debs -type f -exec sha256sum {} \; | sort > sha256sums.txt
 """)], doStepIf=lambda step: hasFiles(step) and savePackage(step))

--- a/buildbot/maria-master.cfg
+++ b/buildbot/maria-master.cfg
@@ -3955,7 +3955,7 @@ old_ver=`dpkg -l | grep -iE 'mysql-server-|mariadb-server-' | head -1 | awk '{pr
 version_arch="""+version_name+"-"+arch+"""
 dist_name="""+dist_name+"""
 version_name="""+version_name+"""
-package_version=`ls debs/binary/mariadb-server_* | head -n 1 | sed -e 's/.*mariadb-server_\([0-9]*\.[0-9]*\.[0-9]*\).*/\\1/'`
+package_version=`ls debs/mariadb-server_* | head -n 1 | sed -e 's/.*mariadb-server_\([0-9]*\.[0-9]*\.[0-9]*\).*/\\1/'`
 
 packages_to_install="mariadb-server mariadb-client libmariadbclient18"
 
@@ -4413,7 +4413,7 @@ sudo sh -c "echo mariadb-10.6 any >> /usr/share/lto-disabled-list/lto-disabled-l
 sudo sh -c "echo mariadb-10.7 any >> /usr/share/lto-disabled-list/lto-disabled-list" || true
 sudo sh -c "echo mariadb-10.8 any >> /usr/share/lto-disabled-list/lto-disabled-list" || true
 cd buildbot
-mkdir -p debs/binary debs/source
+mkdir -p debs/
 rm -Rf build
 mkdir build
 cd build
@@ -4425,10 +4425,12 @@ export AM_EXTRA_MAKEFLAGS=VERBOSE=1
 export DEB_BUILD_OPTIONS=parallel=4
 export DH_BUILD_DDEBS=1
 echo | debian/autobake-deb.sh
-cp `find .. -maxdepth 1 -type f` ../../debs/binary/
+find .. -maxdepth 1 -type f -exec cp {} ../../debs/ \;
 cd ../../debs
-dpkg-scanpackages binary /dev/null | gzip -9c > binary/Packages.gz
-dpkg-scansources source /dev/null | gzip -9c > source/Sources.gz
+( dpkg-scanpackages . /dev/null && dpkg-scanpackages --type ddeb . /dev/null  )| gzip -9c > Packages.gz
+dpkg-scansources . /dev/null | gzip -9c > Sources.gz
+cd ..
+find debs -type f -exec sha256sum {} \; | sort > sha256sums.txt
 """),
         "= rm -Rf debs",
         "= scp -r -P "+getport()+" "+kvm_scpopt+" buildbot@localhost:buildbot/debs .",
@@ -4451,9 +4453,9 @@ if [ $num_providers_expected -eq 0 ] ; then
   exit
 fi
 
-ls debs/binary/mariadb-plugin-provider*
+ls debs/mariadb-plugin-provider*
 
-num_providers_built=`ls debs/binary/mariadb-plugin-provider*.deb | grep -v dbgsym | wc -l`
+num_providers_built=`ls debs/mariadb-plugin-provider*.deb | grep -v dbgsym | wc -l`
 
 if [ $num_providers_built -ne $num_providers_expected ] ; then
   echo "ERROR: Found $num_providers_built provider libraries, expected $num_providers_expected"
@@ -4558,8 +4560,8 @@ sudo sh -c 'echo "deb-src [trusted=yes allow-insecure=yes] file:///home/buildbot
 cd buildbot
 chmod -cR go+r debs galera-debs
 
-if [ -e debs/binary/Packages.gz ] ; then
-    gunzip debs/binary/Packages.gz
+if [ -e debs/Packages.gz ] ; then
+    gunzip debs/Packages.gz
 fi
 if [ -e galera-debs/binary/Packages.gz ] ; then
     gunzip galera-debs/binary/Packages.gz
@@ -4567,15 +4569,15 @@ fi
 
 # Due to MDEV-14622 and its effect on engine installation,
 # Spider and Columnstore have to be installed separately after the server
-package_list=`grep -B 1 'Source: mariadb-' debs/binary/Packages | grep 'Package:' | grep -vE 'galera|spider|columnstore' | awk '{print $2}' | xargs`
-if grep -i spider debs/binary/Packages > /dev/null ; then
-  spider_package_list=`grep -B 1 'Source: mariadb-' debs/binary/Packages | grep 'Package:' | grep 'spider' | awk '{print $2}' | xargs`
+package_list=`grep -B 1 'Source: mariadb-' debs/Packages | grep 'Package:' | grep -vE 'galera|spider|columnstore' | awk '{print $2}' | xargs`
+if grep -i spider debs/Packages > /dev/null ; then
+  spider_package_list=`grep -B 1 'Source: mariadb-' debs/Packages | grep 'Package:' | grep 'spider' | awk '{print $2}' | xargs`
 fi
-if grep -i columnstore debs/binary/Packages > /dev/null ; then
+if grep -i columnstore debs/Packages > /dev/null ; then
   if [[ "$arch" == "x86" ]] ; then
     echo "Installation warning: Due to MCOL-4123, Columnstore won't be installed on x86"
   else
-    columnstore_package_list=`grep -B 1 'Source: mariadb-' debs/binary/Packages | grep 'Package:' | grep 'columnstore' | awk '{print $2}' | xargs`
+    columnstore_package_list=`grep -B 1 'Source: mariadb-' debs/Packages | grep 'Package:' | grep 'columnstore' | awk '{print $2}' | xargs`
   fi
 fi
 
@@ -4816,7 +4818,7 @@ then
   exit 1
 fi
 
-cd debs/binary
+cd debs/
 packages_to_install=`ls *.deb | awk -F'_' '{print $1}' | xargs`
 
 if [[ "%(majorVersion)s" == "10.1" ]] && [[ "$version_name" == "sid" ]]
@@ -5012,7 +5014,7 @@ chmod -cR go+r ~/buildbot/debs
 # Detect the MariaDB version under test from the package name
 # e.g. mariadb-server_5.5.55+maria-1~trusty_all.deb
 
-mariadb_version=`ls ~/buildbot/debs/binary/mariadb-server*all.deb | sed -e 's/.*mariadb-server_\([0-9]*\.[0-9]*\.[0-9]*\)+maria.*/\\1/'`
+mariadb_version=`ls ~/buildbot/debs/mariadb-server*all.deb | sed -e 's/.*mariadb-server_\([0-9]*\.[0-9]*\.[0-9]*\)+maria.*/\\1/'`
 major_version=`echo $mariadb_version | sed -e 's/^\([0-9]*\.[0-9]*\)\.[0-9]*$/\\1/'`
 echo $mariadb_version > /tmp/version.target
 
@@ -5189,7 +5191,7 @@ def getGalDebBuilder(name, kvm_image, cpu, dist_name, version_name, kvmargs=[], 
         WithProperties("""
 set -ex
 cd buildbot
-mkdir -p debs/binary debs/source
+mkdir -p debs/
 chmod -cR go+r debs
 git clone -b %(branch)s "https://github.com/MariaDB/galera.git" build
 cd build
@@ -5197,11 +5199,12 @@ git reset --hard %(revision)s
 git submodule init
 git submodule update
 ./scripts/build.sh -p
-cp `find ../*.deb -maxdepth 1 -type f` ../debs/binary/
-cp `find ../*.changes -maxdepth 1 -type f` ../debs/binary/
+find .. -maxdepth 1 -type f \( -name \*.dsc -o -name \*.*z  -o -name \*changes -o -name \*buildinfo \) -exec cp {} ../debs/ \;
 cd ../debs
-dpkg-scanpackages binary /dev/null | gzip -9c > binary/Packages.gz
-dpkg-scansources source /dev/null | gzip -9c > source/Sources.gz
+( dpkg-scanpackages . /dev/null && dpkg-scanpackages --type ddeb . /dev/null  )| gzip -9c > Packages.gz
+dpkg-scansources . /dev/null | gzip -9c > Sources.gz
+cd ..
+find debs -type f -exec sha256sum {} \; | sort > sha256sums.txt
 """),
         "= rm -Rf debs",
         "= scp -r -P "+getport()+" "+kvm_scpopt+" buildbot@localhost:buildbot/debs .",
@@ -5230,7 +5233,7 @@ for i in 1 2 3 4 5 6 7 8 9 10 ; do
   sleep 10
 done
 
-sudo sh -c "if [ -e /home/buildbot/buildbot/debs/binary/galera-4_*.deb ] ; then pkgs='galera-4 galera-arbitrator-4'; else pkgs='galera-3 galera-arbitrator-3'; fi; DEBIAN_FRONTEND=noninteractive MYSQLD_STARTUP_TIMEOUT=180 apt-get install --allow-unauthenticated -y \$pkgs"
+sudo sh -c "if [ -e /home/buildbot/buildbot/debs/galera-4_*.deb ] ; then pkgs='galera-4 galera-arbitrator-4'; else pkgs='galera-3 galera-arbitrator-3'; fi; DEBIAN_FRONTEND=noninteractive MYSQLD_STARTUP_TIMEOUT=180 apt-get install --allow-unauthenticated -y \$pkgs"
 garbd --version
 """),
         "! rm -f daemon.log; (sudo cat /var/log/daemon.log || sudo cat /var/log/syslog) >daemon.log",

--- a/release/mkrepo-debian.sh
+++ b/release/mkrepo-debian.sh
@@ -294,10 +294,10 @@ for dist in ${debian_dists}; do
   builder_dir="builder_dir_${build_type}_amd64[${builder}]"
   case ${builder} in 
     'jessie')
-      runCommand reprepro --basedir=. include ${dist} $ARCHDIR/${!builder_dir}/debs/binary/mariadb-*_amd64.changes
+      runCommand reprepro --basedir=. include ${dist} $ARCHDIR/${!builder_dir}/debs/mariadb-*_amd64.changes
       ;;
     'stretch'|'buster'|'sid')
-      runCommand reprepro --basedir=. --ignore=wrongsourceversion include ${dist} $ARCHDIR/${!builder_dir}/debs/binary/mariadb-*_amd64.changes
+      runCommand reprepro --basedir=. --ignore=wrongsourceversion include ${dist} $ARCHDIR/${!builder_dir}/debs/mariadb-*_amd64.changes
       ;;
     * )
       for i in $(find "$ARCHDIR/${!builder_dir}/" -name '*.deb'); do runCommand reprepro --basedir=. includedeb ${dist} $i ; done

--- a/release/mkrepo-ubuntu.sh
+++ b/release/mkrepo-ubuntu.sh
@@ -184,7 +184,7 @@ for dist in ${ubuntu_dists}; do
   builder_dir="builder_dir_${build_type}_amd64[${dist}]"
   case ${dist} in 
     'bionic'|'focal'|'hirsute'|'impish')
-      runCommand reprepro --basedir=. --ignore=wrongsourceversion include ${dist} $ARCHDIR/${!builder_dir}/debs/binary/mariadb-*_amd64.changes
+      runCommand reprepro --basedir=. --ignore=wrongsourceversion include ${dist} $ARCHDIR/${!builder_dir}/debs/mariadb-*_amd64.changes
       ;;
   esac
 


### PR DESCRIPTION
This copies of the Foundations construction of the deb repository. With this layout the repo file of the following can be used:

deb [trusted=yes] http://hasky.askmonty.org/archive/10.6/build-44208/kvm-deb-impish-amd64/debs/ ./

This can be also used for the debuginfo packages.

I've attempted to include all the locations where the paths of /binary are expected.