### PR TITLE
bb.org: correct tarbuildnum

### DIFF
--- a/buildbot.mariadb.org/master.cfg
+++ b/buildbot.mariadb.org/master.cfg
@@ -530,9 +530,9 @@ f_tarball.addStep(steps.SetPropertyFromCommand(command="ls -1 *.tar.gz", extract
 #    masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:buildnumber)s'), url=util.Interpolate('https://ci.mariadb.org/' + "%(prop:buildnumber)s"), urlText="Download", doStepIf=hasFiles))
 f_tarball.addStep(steps.ShellCommand(name='save_packages', haltOnFailure=True, command=util.Interpolate('cp -r ' + '%(prop:builddir)s' + '/build/mkdist/' + '%(prop:buildnumber)s' + ' /packages && sync /packages/' + '%(prop:buildnumber)s')))
 f_tarball.addStep(steps.Trigger(schedulerNames=['s_protected_branches'], waitForFinish=False, updateSourceStamp=False, doStepIf=waitIfStaging,
-    set_properties={"tarbuildnum" : Property("buildnumber"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch")}))
+    set_properties={"tarbuildnum" : Property("tarbuildnum"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch")}))
 f_tarball.addStep(steps.Trigger(schedulerNames=['s_upstream_all'], waitForFinish=False, updateSourceStamp=False,
-    set_properties={"tarbuildnum" : Property("buildnumber"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch")}))
+    set_properties={"tarbuildnum" : Property("tarbuildnum"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch")}))
 f_tarball.addStep(steps.SetPropertyFromCommand(command=util.Interpolate("echo " + "prot-" + "%(prop:master_branch)s"), property="master_staging_branch"))
 f_tarball.addStep(steps.ShellSequence( commands=[
     util.ShellArg(command="git config --global user.email '" + config["private"]["gh_mdbci"]["email"] + "'"),


### PR DESCRIPTION
This probably causing errors like https://buildbot.mariadb.org/#/builders/219/builds/1255/steps/3/logs/stdio

```
sudo sh -c 'echo '\''deb [trusted=yes] https://ci.mariadb.org/1255/amd64-ubuntu-1804-deb-autobake/debs .'\'' >> /etc/apt/sources.list'
....
+ sudo apt-get update
E: Malformed entry 55 in list file /etc/apt/sources.list (Component)
E: The list of sources could not be read.
```

tarbuildnum is in the scripts (top of https://github.com/MariaDB/mariadb.org-tools/blob/master/buildbot.mariadb.org/scripts/deb-major-upgrade.sh#L7).

I'd like a quick check/deployment monitoring to ensure this is the only impact.