### PR TITLE
bb.org: Change dependency branch for all deb based builders to 10.7

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -34,11 +34,11 @@ jobs:
           #   platforms: linux/arm64/v8
           - dockerfile: debian.Dockerfile
             image: debian:9
-            branch: 10.5
+            branch: 10.7
             platforms: linux/386, linux/amd64, linux/arm64/v8
           - dockerfile: debian.Dockerfile
             image: debian:10
-            branch: 10.5
+            branch: 10.7
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
           - dockerfile: debian.Dockerfile
             image: debian:11
@@ -50,11 +50,11 @@ jobs:
             platforms: linux/386, linux/amd64, linux/arm64/v8, linux/ppc64le
           - dockerfile: debian.Dockerfile
             image: ubuntu:18.04
-            branch: 10.5
+            branch: 10.7
             platforms: linux/386, linux/amd64, linux/arm64/v8, linux/ppc64le
           - dockerfile: debian.Dockerfile
             image: ubuntu:20.04
-            branch: 10.5
+            branch: 10.7
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
           - dockerfile: debian.Dockerfile
             image: ubuntu:21.04


### PR DESCRIPTION
There are missing dependencies for Deb based builders for 10.7 and 10.8 branches (for example https://buildbot.mariadb.org/#/builders/99/builds/5855). Change the base branch for all deb based Docker images to 10.7 so that this issue is solved.