### PR TITLE
Build 10.7 on older Debian versions

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -34,11 +34,11 @@ jobs:
           #   platforms: linux/arm64/v8
           - dockerfile: debian.Dockerfile
             image: debian:9
-            branch: 10.5
+            branch: 10.7
             platforms: linux/386, linux/amd64, linux/arm64/v8
           - dockerfile: debian.Dockerfile
             image: debian:10
-            branch: 10.5
+            branch: 10.7
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
           - dockerfile: debian.Dockerfile
             image: debian:11
@@ -50,11 +50,11 @@ jobs:
             platforms: linux/386, linux/amd64, linux/arm64/v8, linux/ppc64le
           - dockerfile: debian.Dockerfile
             image: ubuntu:18.04
-            branch: 10.5
+            branch: 10.7
             platforms: linux/386, linux/amd64, linux/arm64/v8, linux/ppc64le
           - dockerfile: debian.Dockerfile
             image: ubuntu:20.04
-            branch: 10.5
+            branch: 10.7
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
           - dockerfile: debian.Dockerfile
             image: ubuntu:21.04


### PR DESCRIPTION
This permits to build 10.7 on the following OS version (previously only targeting 10.5):
- Debian 9
- Debian 10
- Ubuntu 18.04
- Ubuntu 20.04

For some old OS version, some dependencies are not available and should be skipped.