### PR TITLE
Fix MDBF-329

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -75,9 +75,9 @@ jobs:
           - dockerfile: centos7.Dockerfile
             image: centos:7
             platforms: linux/amd64, linux/arm64/v8
-          - dockerfile: centos.Dockerfile
-            image: centos:8
-            platforms: linux/amd64, linux/arm64/v8
+          # - dockerfile: centos.Dockerfile
+          #   image: centos:8
+          #   platforms: linux/amd64, linux/arm64/v8
           - dockerfile: rhel7.Dockerfile
             image: rhel7
             platforms: linux/amd64

--- a/buildbot.mariadb.org/ci_build_images/common.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/common.Dockerfile
@@ -26,6 +26,10 @@ RUN gosu buildbot curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs >/tm
     && pip3 install --no-cache-dir -U pip \
     && gosu buildbot curl -so /home/buildbot/requirements.txt \
     https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/buildbot.mariadb.org/ci_build_images/requirements.txt \
+    # https://jira.mariadb.org/browse/MDBF-329 \
+    && if grep -q "stretch" /etc/apt/sources.list; then \
+        gosu buildbot bash -c "pip3 install --no-cache-dir --no-warn-script-location incremental"; \
+    fi \
     && gosu buildbot bash -c "pip3 install --no-cache-dir --no-warn-script-location -r /home/buildbot/requirements.txt"
 
 # TODO: sync with BB steps (move to /home/buildbot)


### PR DESCRIPTION
Fix a python dependency on Debian 9

twisted[tls] can't be installed on Debian 9 (ARM) without the `incremental` packages,
and somehow, it is not installed automatically.
See: https://jira.mariadb.org/browse/MDBF-329

+ disable Centos8:
See: https://forums.centos.org/viewtopic.php?f=54&t=78708