### PR TITLE
Add missing dependency for Debian sid

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -29,9 +29,9 @@ jobs:
         include:
           # TODO: missing ppc64le/debian:9 image
           # TODO: problem with pip
-          # - dockerfile: rhel7.Dockerfile
-          #   image: rhel7-aarch64
-          #   platforms: linux/arm64/v8
+          ## - dockerfile: rhel7.Dockerfile
+          ##   image: rhel7-aarch64
+          ##   platforms: linux/arm64/v8
           - dockerfile: debian.Dockerfile
             image: debian:9
             branch: 10.7
@@ -70,14 +70,14 @@ jobs:
           - dockerfile: fedora.Dockerfile
             image: fedora:35
             platforms: linux/amd64, linux/arm64/v8
-          # TODO: linux/ppc64le pb when installing bb-worker with pip
-          # "ModuleNotFoundError: No module named '_cffi_backend'"
+          # # TODO: linux/ppc64le pb when installing bb-worker with pip
+          # # "ModuleNotFoundError: No module named '_cffi_backend'"
           - dockerfile: centos7.Dockerfile
             image: centos:7
             platforms: linux/amd64, linux/arm64/v8
-          # - dockerfile: centos.Dockerfile
-          #   image: centos:8
-          #   platforms: linux/amd64, linux/arm64/v8
+          ## - dockerfile: centos.Dockerfile
+          ##   image: centos:8
+          ##   platforms: linux/amd64, linux/arm64/v8
           - dockerfile: rhel7.Dockerfile
             image: rhel7
             platforms: linux/amd64

--- a/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
@@ -22,7 +22,7 @@ RUN if grep -q "ID=debian" /etc/os-release; then \
 # see: https://cryptography.io/en/latest/installation/
 RUN apt-get update \
     && apt-get -y upgrade \
-    && apt-get -y install --no-install-recommends equivs devscripts curl \
+    && apt-get -y install --no-install-recommends curl devscripts equivs \
     && curl -skO https://raw.githubusercontent.com/MariaDB/server/$mariadb_branch/debian/control \
     # skip unavailable deps on Debian 9 \
     && if grep -q 'stretch' /etc/apt/sources.list; then \
@@ -64,6 +64,7 @@ RUN apt-get update \
     libboost-dev \
     libboost-filesystem-dev \
     libboost-program-options-dev \
+    libdistro-info-perl \
     libffi-dev \
     libssl-dev \
     python3-dev \


### PR DESCRIPTION
See: https://jira.mariadb.org/browse/MDBF-330

+ adding double comments to be sure we do not accidentally uncomment OS we do not want to build.