### PR TITLE
libzstd-dev (>= 1.1.3) is needed on Debian9

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -27,11 +27,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # TODO: missing ppc64le/debian:9 image
-          # TODO: problem with pip
-          ## - dockerfile: rhel7.Dockerfile
-          ##   image: rhel7-aarch64
-          ##   platforms: linux/arm64/v8
+          # # TODO: missing ppc64le/debian:9 image
+          # # TODO: problem with pip
+          # # - dockerfile: rhel7.Dockerfile
+          # #   image: rhel7-aarch64
+          # #   platforms: linux/arm64/v8
           - dockerfile: debian.Dockerfile
             image: debian:9
             branch: 10.7
@@ -72,12 +72,12 @@ jobs:
             platforms: linux/amd64, linux/arm64/v8
           # # TODO: linux/ppc64le pb when installing bb-worker with pip
           # # "ModuleNotFoundError: No module named '_cffi_backend'"
-          - dockerfile: centos7.Dockerfile
-            image: centos:7
+          # # - dockerfile: centos7.Dockerfile
+          # #   image: centos:7
+          # #   platforms: linux/amd64, linux/arm64/v8
+          - dockerfile: centos.Dockerfile
+            image: centos:8
             platforms: linux/amd64, linux/arm64/v8
-          ## - dockerfile: centos.Dockerfile
-          ##   image: centos:8
-          ##   platforms: linux/amd64, linux/arm64/v8
           - dockerfile: rhel7.Dockerfile
             image: rhel7
             platforms: linux/amd64

--- a/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
@@ -26,9 +26,12 @@ RUN apt-get update \
     && curl -skO https://raw.githubusercontent.com/MariaDB/server/$mariadb_branch/debian/control \
     # skip unavailable deps on Debian 9 \
     && if grep -q 'stretch' /etc/apt/sources.list; then \
+        # activate backports to install a recent version of libzstd-dev (>= 1.1.3).
+        echo "deb http://deb.debian.org/debian stretch-backports main" >/etc/apt/sources.list.d/bpo.list; \
+        apt-get update; \
+        apt-get -y install --no-install-recommends -t stretch-backports libzstd-dev; \
         sed '/libpmem-dev/d' -i control; \
         sed '/liburing-dev/d' -i control; \
-        sed '/libzstd-dev/d' -i control; \
     fi \
     # skip unavailable deps on Debian 10 \
     && if grep -q 'buster' /etc/apt/sources.list; then \


### PR DESCRIPTION
See: https://jira.mariadb.org/browse/MDBF-346