### PR TITLE
MDBF-349: Add Ubuntu 22.04 for ci_workers

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -64,6 +64,10 @@ jobs:
             image: ubuntu:21.10
             branch: 10.7
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
+          - dockerfile: debian.Dockerfile
+            image: ubuntu:22.04
+            branch: 10.7
+            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
           - dockerfile: fedora.Dockerfile
             image: fedora:34
             platforms: linux/amd64, linux/arm64/v8


### PR DESCRIPTION
Seems to not need any exclusions from dependencies

Will look at bb config once workers are added.