### PR TITLE
Fix centos:7 ppc64le pip problem

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -27,11 +27,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # # TODO: missing ppc64le/debian:9 image
-          # # TODO: problem with pip
-          # # - dockerfile: rhel7.Dockerfile
-          # #   image: rhel7-aarch64
-          # #   platforms: linux/arm64/v8
+          # TODO: missing ppc64le/debian:9 image
+          # TODO: problem with pip
+          # - dockerfile: rhel7.Dockerfile
+          #   image: rhel7-aarch64
+          #   platforms: linux/arm64/v8
           - dockerfile: debian.Dockerfile
             image: debian:9
             branch: 10.7
@@ -70,11 +70,9 @@ jobs:
           - dockerfile: fedora.Dockerfile
             image: fedora:35
             platforms: linux/amd64, linux/arm64/v8
-          # TODO: linux/ppc64le pb when installing bb-worker with pip
-          # "ModuleNotFoundError: No module named '_cffi_backend'"
           - dockerfile: centos7.Dockerfile
             image: centos:7
-            platforms: linux/amd64, linux/arm64/v8
+            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
           - dockerfile: centos.Dockerfile
             image: quay.io/centos/centos:stream8
             platforms: linux/amd64, linux/arm64/v8


### PR DESCRIPTION
For centos7 (ppc64le), it's necessary to install specific pip packages versions.

See:
https://jira.mariadb.org/browse/MDBF-273?focusedCommentId=216315