### PR TITLE
release: docker library from next branch

### DIFF
--- a/release/prep
+++ b/release/prep
@@ -1456,7 +1456,7 @@ update_the_docker_library_mariadb_version() {
     runCommand git clone git@github.com:MariaDB/mariadb-docker ${dir_docker}
   fi
   pushd ${dir_docker_library}
-    #runCommand git checkout ${major}
+    runCommand git checkout next
     runCommand git pull
     if test -d ${major}; then       # only update version if the dir exists
       runCommand ./update.sh "${num}"


### PR DESCRIPTION
To keep the docker library master branch as something
that can be built with existing releases, and the next
branch having feature that are from the next server version,
releases have to be done from the next branch.