### PR TITLE
MDEV-28153: use static control dependencies adjusted by autobake-deb.sh

### DIFF
--- a/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
@@ -22,40 +22,15 @@ RUN if grep -q "ID=debian" /etc/os-release; then \
 # see: https://cryptography.io/en/latest/installation/
 RUN apt-get update \
     && apt-get -y upgrade \
-    && apt-get -y install --no-install-recommends curl devscripts equivs \
+    && apt-get -y install --no-install-recommends curl devscripts equivs lsb-release \
     && curl -skO https://raw.githubusercontent.com/MariaDB/server/$mariadb_branch/debian/control \
-    # MDEV-27965 - temporary hack to introduce a late libfmt dependency, so \
-    # the main branches don't immediately fail on autobake builders once \
-    # https://github.com/MariaDB/server/pull/2062 is merged. \
-    && sed -i -e '/libedit-dev:native/a\\               libfmt-dev (>= 7.0.0),' control \
-    # skip unavailable deps on Debian 9 \
-    && if grep -q 'stretch' /etc/apt/sources.list; then \
-        sed '/libfmt-dev/d' -i control; \
-        sed '/libpmem-dev/d' -i control; \
-        sed '/liburing-dev/d' -i control; \
-        sed '/libzstd-dev/d' -i control; \
-    fi \
-    # skip unavailable deps on Debian 10 \
-    && if grep -q 'buster' /etc/apt/sources.list; then \
-        # libpmem-dev is not available on buster ARM/PPC \
-        if [ "$(uname -m)" != "x86_64" ]; then \
-            sed '/libpmem-dev/d' -i control; \
-        fi; \
-        sed '/libfmt-dev/d' -i control; \
-        sed '/liburing-dev/d' -i control; \
-    fi \
-    # skip unavailable deps on Ubuntu 18.04 \
-    && if grep -q 'bionic' /etc/apt/sources.list; then \
-        sed '/libfmt-dev/d' -i control; \
-        sed '/libpmem-dev/d' -i control; \
-        sed '/liburing-dev/d' -i control; \
-    fi \
-    # skip unavailable deps on Ubuntu 20.04 \
-    && if grep -q 'focal' /etc/apt/sources.list; then \
-        sed '/libfmt-dev/d' -i control; \
-        sed '/liburing-dev/d' -i control; \
-    fi \
-    && mk-build-deps -r -i control \
+    && mkdir debian \
+    && mv control debian/control \
+    && touch debian/rules VERSION debian/not-installed \
+    && curl -skO https://raw.githubusercontent.com/MariaDB/server/$mariadb_branch/debian/autobake-deb.sh \
+    && chmod a+x autobake-deb.sh \
+    && AUTOBAKE_PREP_CONTROL_RULES_ONLY=1 ./autobake-deb.sh \
+    && mk-build-deps -r -i debian/control \
     -t 'apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends' \
     && apt-get -y build-dep -q mariadb-server \
     && apt-get -y install --no-install-recommends \


### PR DESCRIPTION
This solves a few debian:9 / ubuntu:18.04 problems.

At the moments, it's depending on https://github.com/MariaDB/server/pull/2064 merged up to 10.7 where the deb build generates from.

For the moment I've tested with:
```
$ buildah bud --build-arg  mariadb_branch=bb-10.5-danielblack-MDEV-28153-deb-explict-deps-salsa-postfix --build-arg base_image=ubuntu:18.04 --tag bb:u1804 -f debian.Dockerfile
```
And
```
$ buildah bud --build-arg  mariadb_branch=bb-10.5-danielblack-MDEV-28153-deb-explict-deps-salsa-postfix --build-arg base_image=debian:9 --tag bb:deb9 -f debian.Dockerfile
```
Which generates an image.

There's a small gap that it doesn't (yet?) pull columnstore dependencies.