### PR TITLE
bb.org: Add gnutls for Debian 9 images

### DIFF
--- a/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
@@ -80,4 +80,8 @@ RUN apt-get update \
     scons \
     sudo  \
     wget \
+    # install Debian 9 only deps \
+    && if grep -q 'stretch' /etc/apt/sources.list; then \
+        apt-get -y install --no-install-recommends gnutls-dev; \
+    fi \
     && apt-get clean


### PR DESCRIPTION
gnutls is needed to prevent failures such as
https://buildbot.mariadb.org/#/builders/242/builds/5267.