### PR TITLE
bb.org: Add pcre2-devel for RHEL 7

### DIFF
--- a/buildbot.mariadb.org/ci_build_images/rhel7.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/rhel7.Dockerfile
@@ -28,6 +28,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     libffi-devel \
     libxml2-devel \
     lz4-devel \
+    pcre2-devel \
     python3-pip \
     scons \
     snappy-devel \


### PR DESCRIPTION
pcre2-devel is needed in order to solve the following build issues:

CMake Error at cmake/pcre.cmake:83 (MESSAGE):
  system pcre2-8 library is not found or unusable

as shown in https://buildbot.mariadb.org/#/builders/162/builds/8625