### PR TITLE
MDBF-404: Add tagging to README.md

### DIFF
--- a/buildbot.mariadb.org/ci_build_images/README.md
+++ b/buildbot.mariadb.org/ci_build_images/README.md
@@ -7,16 +7,16 @@ Command line example to manually build containers:
 ```console
 # debian
 cat debian.Dockerfile common.Dockerfile >/tmp/Dockerfile
-docker build . -f /tmp/Dockerfile --build-arg mariadb_branch=10.7 --build-arg base_image=debian:sid
+docker build . -f /tmp/Dockerfile -t mariadb.org/buildbot/debian:sid --build-arg mariadb_branch=10.7 --build-arg base_image=debian:sid
 # ubuntu
 cat debian.Dockerfile common.Dockerfile >/tmp/Dockerfile
-docker build . -f /tmp/Dockerfile --build-arg mariadb_branch=10.7 --build-arg base_image=ubuntu:21.04
+docker build . -f /tmp/Dockerfile -t mariadb.org/buildbot/ubuntu:21.04 --build-arg mariadb_branch=10.7 --build-arg base_image=ubuntu:21.04
 # fedora
 cat fedora.Dockerfile common.Dockerfile >/tmp/Dockerfile
-docker build . -f /tmp/Dockerfile --build-arg base_image=fedora:34
+docker build . -f /tmp/Dockerfile -t mariadb.org/buildbot/fedora:34 --build-arg base_image=fedora:34
 # rhel8
 cat rhel8.Dockerfile common.Dockerfile >/tmp/Dockerfile
-docker build . -f /tmp/Dockerfile --build-arg "rhel_user=user" --build-arg "rhel_pwd=password"
+docker build . -f /tmp/Dockerfile -t mariadb.org/buildbot/rhel:8 --build-arg "rhel_user=user" --build-arg "rhel_pwd=password"
 ```
 
 ## search for missing dependencies


### PR DESCRIPTION
Add tagging to 'manually build containers' instructions so it'll easier to use builded images