### PR TITLE
MDBF-403: Add rpmlint to RPM based distro docker images

### DIFF
--- a/buildbot.mariadb.org/ci_build_images/centos.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/centos.Dockerfile
@@ -32,6 +32,7 @@ RUN dnf -y --enablerepo=extras install epel-release \
     python3-devel \
     python3-scons \
     readline-devel \
+    rpmlint \
     ruby \
     snappy-devel \
     subversion \
@@ -57,4 +58,3 @@ RUN dnf -y --enablerepo=extras install epel-release \
 # RUN wget http://yum.mariadb.org/10.5.6/centos8-amd64/srpms/MariaDB-10.5.6-1.el8.src.rpm
 # RUN rpm -ivh ./MariaDB-10.5.6-1.el8.src.rpm
 # RUN yum-builddep -y ~/rpmbuild/SPECS/*
-

--- a/buildbot.mariadb.org/ci_build_images/centos7.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/centos7.Dockerfile
@@ -36,6 +36,7 @@ RUN yum -y --enablerepo=extras install epel-release \
     pcre2-devel \
     python3 \
     python3-pip \
+    rpmlint \
     ruby \
     scons \
     snappy-devel \
@@ -60,4 +61,3 @@ RUN yum -y --enablerepo=extras install epel-release \
         "ppc64le") curl -sL "https://github.com/tianon/gosu/releases/download/1.14/gosu-ppc64el" >/usr/local/bin/gosu ;; \
     esac \
     && chmod +x /usr/local/bin/gosu
-

--- a/buildbot.mariadb.org/ci_build_images/fedora.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/fedora.Dockerfile
@@ -37,6 +37,7 @@ RUN dnf -y upgrade \
     python3-pip \
     readline-devel \
     rpm-build \
+    rpmlint \
     rubypick \
     scons \
     snappy-devel \
@@ -51,4 +52,3 @@ RUN dnf -y upgrade \
         "ppc64le") curl -sL "https://github.com/tianon/gosu/releases/download/1.14/gosu-ppc64el" >/usr/local/bin/gosu ;; \
     esac \
     && chmod +x /usr/local/bin/gosu
-

--- a/buildbot.mariadb.org/ci_build_images/rhel7.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/rhel7.Dockerfile
@@ -30,6 +30,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     lz4-devel \
     pcre2-devel \
     python3-pip \
+    rpmlint \
     scons \
     snappy-devel \
     wget \

--- a/buildbot.mariadb.org/ci_build_images/rhel8.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/rhel8.Dockerfile
@@ -51,6 +51,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     python3-devel \
     python3-scons \
     readline-devel \
+    rpmlint \
     ruby \
     snappy-devel \
     subversion \
@@ -72,4 +73,3 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
         "ppc64le") curl -sL "https://github.com/tianon/gosu/releases/download/1.14/gosu-ppc64el" >/usr/local/bin/gosu ;; \
     esac \
     && chmod +x /usr/local/bin/gosu
-

--- a/buildbot.mariadb.org/common_factories.py
+++ b/buildbot.mariadb.org/common_factories.py
@@ -1,5 +1,6 @@
 from buildbot.plugins import *
 from buildbot.process.properties import Property, Properties
+from buildbot.steps.package.rpm.rpmlint import RpmLint
 from buildbot.steps.shell import ShellCommand, Compile, Test, SetPropertyFromCommand
 from buildbot.steps.mtrlogobserver import MTR, MtrLogObserver
 from buildbot.steps.source.github import GitHub
@@ -68,6 +69,7 @@ def getRpmAutobakeFactory(mtrDbPool):
     # build steps
     f_rpm_autobake.addStep(steps.ShellCommand(logfiles={'CMakeCache.txt': 'CMakeCache.txt'}, name="cmake", command=
         ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DBUILD_CONFIG=mysql_release -DRPM=%(kw:rpm_type)s -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache  %(kw:mtr_additional_args)s", mtr_additional_args=util.Property('mtr_additional_args', default=''), rpm_type=util.Property('rpm_type'))], env={'CCACHE_DIR':'/mnt/ccache'}, description="cmake"))
+    f_rpm_autobake.addStep(steps.RpmLint())
     f_rpm_autobake.addStep(steps.Compile(command=
         ["sh", "-xc", util.Interpolate("""
             mkdir -p rpms srpms
@@ -100,4 +102,3 @@ def getRpmAutobakeFactory(mtrDbPool):
         set_properties={"tarbuildnum" : Property("tarbuildnum"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch"), "parentbuildername": Property("buildername")}, doStepIf=lambda step: hasUpgrade(step) and savePackage(step) and hasFiles(step)))
     f_rpm_autobake.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
     return f_rpm_autobake
-


### PR DESCRIPTION
Add tool [rpmlint](https://github.com/rpm-software-management/rpmlint) package to RPM based distro docker images. Rpmlint is good tool to test if builded RPM follows good RPM guidelines and available as build in BuildBot. First add Rpmlint to container images.