### PR TITLE
MDBF-405: Add check_for_missing_breaks_replaces.py to Debian image

### DIFF
--- a/buildbot.mariadb.org/ci_build_images/common.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/common.Dockerfile
@@ -39,6 +39,9 @@ RUN gosu buildbot curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs >/tm
             gosu buildbot bash -c "pip3 install --no-cache-dir --no-warn-script-location incremental"; \
         fi; \
         gosu buildbot bash -c "pip3 install --no-cache-dir --no-warn-script-location -r /home/buildbot/requirements.txt"; \
+    fi \
+    && if grep -qi "debian" /etc/os-release; then \
+        pip3 install --no-cache-dir --no-warn-script-location python-debian junit_xml; \
     fi
 
 # TODO: sync with BB steps (move to /home/buildbot)

--- a/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
@@ -22,7 +22,7 @@ RUN if grep -q "ID=debian" /etc/os-release; then \
 # see: https://cryptography.io/en/latest/installation/
 RUN apt-get update \
     && apt-get -y upgrade \
-    && apt-get -y install --no-install-recommends curl devscripts equivs \
+    && apt-get -y install --no-install-recommends ca-certificates curl devscripts equivs \
     && curl -skO https://raw.githubusercontent.com/MariaDB/server/$mariadb_branch/debian/control \
     # MDEV-27965 - temporary hack to introduce a late libfmt dependency, so \
     # the main branches don't immediately fail on autobake builders once \

--- a/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
@@ -55,6 +55,10 @@ RUN apt-get update \
         sed '/libfmt-dev/d' -i control; \
         sed '/liburing-dev/d' -i control; \
     fi \
+    && curl \
+       https://salsa.debian.org/salsa-ci-team/pipeline/-/raw/master/images/scripts/check_for_missing_breaks_replaces.py \
+       > /usr/local/bin/check_for_missing_breaks_replaces.py \
+    && chmod +x /usr/local/bin/check_for_missing_breaks_replaces.py \
     && mk-build-deps -r -i control \
     -t 'apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends' \
     && apt-get -y build-dep -q mariadb-server \


### PR DESCRIPTION
Because check_for_missing_breaks_replaces.py is not available as DEB package is should be downloaded from [git repository](
https://salsa.debian.org/salsa-ci-team/pipeline/-/raw/master/images/scripts/check_for_missing_breaks_replaces.py)
everytime docker image is build.