### PR TITLE
bb.corp: deb maj/min install/upgrade 10.9 versionless

### DIFF
--- a/buildbot/maria-master.cfg
+++ b/buildbot/maria-master.cfg
@@ -4727,15 +4727,15 @@ fi
 
 # Due to MDEV-14622 and its effect on engine installation,
 # Spider and Columnstore have to be installed separately after the server
-package_list=`grep -B 1 'Source: mariadb-' debs/binary/Packages | grep 'Package:' | grep -vE 'galera|spider|columnstore' | awk '{print $2}' | xargs`
+package_list=`grep -B 1 'Source: mariadb' debs/binary/Packages | grep 'Package:' | grep -vE 'galera|spider|columnstore' | awk '{print $2}' | xargs`
 if grep -i spider debs/binary/Packages > /dev/null ; then
-  spider_package_list=`grep -B 1 'Source: mariadb-' debs/binary/Packages | grep 'Package:' | grep 'spider' | awk '{print $2}' | xargs`
+  spider_package_list=`grep -B 1 'Source: mariadb' debs/binary/Packages | grep 'Package:' | grep 'spider' | awk '{print $2}' | xargs`
 fi
 if grep -i columnstore debs/binary/Packages > /dev/null ; then
   if [[ "$arch" == "x86" ]] ; then
     echo "Installation warning: Due to MCOL-4123, Columnstore won't be installed on x86"
   else
-    columnstore_package_list=`grep -B 1 'Source: mariadb-' debs/binary/Packages | grep 'Package:' | grep 'columnstore' | awk '{print $2}' | xargs`
+    columnstore_package_list=`grep -B 1 'Source: mariadb' debs/binary/Packages | grep 'Package:' | grep 'columnstore' | awk '{print $2}' | xargs`
   fi
 fi
 

--- a/buildbot/steps/minor_upgrade.deb.sh
+++ b/buildbot/steps/minor_upgrade.deb.sh
@@ -67,10 +67,10 @@ all)
   if grep -i columnstore Packages > /dev/null ; then
     echo "Upgrade warning: Due to MCOL-4120 (Columnstore leaves the server shut down) and other bugs Columnstore upgrade is tested separately"
   fi
-  package_list=`grep -B 1 'Source: mariadb-' Packages | grep 'Package:' | grep -vE 'galera|spider|columnstore' | awk '{print $2}' | sort | uniq | xargs`
+  package_list=`grep -B 1 'Source: mariadb' Packages | grep 'Package:' | grep -vE 'galera|spider|columnstore' | awk '{print $2}' | sort | uniq | xargs`
   if grep -i spider Packages > /dev/null ; then
     echo "Upgrade warning: Due to MDEV-14622 Spider will be installed separately after the server"
-    spider_package_list=`grep -B 1 'Source: mariadb-' Packages | grep 'Package:' | grep 'spider' | awk '{print $2}' | sort | uniq | xargs`
+    spider_package_list=`grep -B 1 'Source: mariadb' Packages | grep 'Package:' | grep 'spider' | awk '{print $2}' | sort | uniq | xargs`
   fi
   if grep -i tokudb Packages > /dev/null ; then
     # For the sake of installing TokuDB, disable hugepages
@@ -91,7 +91,7 @@ columnstore)
     echo "Upgrade warning: Columnstore isn't necessarily built on Sid, thte test will be skipped"
     exit
   fi
-  package_list="mariadb-server "`grep -B 1 'Source: mariadb-' Packages | grep 'Package:' | grep 'columnstore' | awk '{print $2}' | sort | uniq | xargs`
+  package_list="mariadb-server "`grep -B 1 'Source: mariadb' Packages | grep 'Package:' | grep 'columnstore' | awk '{print $2}' | sort | uniq | xargs`
   ;;
 *)
   echo "ERROR: unknown test mode: $test_mode"


### PR DESCRIPTION
With MDEV-27033, 10.9 mariadb Packages only contain Source: mariadb

Mirrors 727b92f500d84bfbedb20ad2a52a75b96977bbad change I did which [seems to have worked](https://buildbot.mariadb.org/#/builders/367/builds/218).