### PR TITLE
MDBF-410: Fix building of Ubuntu 20.04-22.04 Docker images

### DIFF
--- a/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
@@ -7,6 +7,7 @@ ARG base_image
 FROM "$base_image"
 ARG mariadb_branch=10.7
 LABEL maintainer="MariaDB Buildbot maintainers"
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Fix Python Cryptography building proble with adding `ENV CARGO_NET_GIT_FETCH_WITH_CLI=true` to Debian common Docker file. It fixes Ubuntu 20.04-22.04 building and does not do any harm to Debian or older Ubuntu image building