### PR TITLE
MDBF-409: Add Lintian steps to DEB build

### DIFF
--- a/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/debian.Dockerfile
@@ -74,6 +74,7 @@ RUN apt-get update \
     libboost-program-options-dev \
     libffi-dev \
     libssl-dev \
+    lintian \
     python3-dev \
     python3-pip \
     python3-setuptools \

--- a/buildbot.mariadb.org/master.cfg
+++ b/buildbot.mariadb.org/master.cfg
@@ -3,6 +3,7 @@
 
 from buildbot.plugins import *
 from buildbot.process.properties import Property, Properties
+from buildbot.steps.package.deb.lintian import DebLintian
 from buildbot.steps.shell import ShellCommand, Compile, Test, SetPropertyFromCommand
 from buildbot.steps.mtrlogobserver import MTR, MtrLogObserver
 from buildbot.steps.source.github import GitHub
@@ -619,6 +620,8 @@ f_deb_autobake.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /m
 # build steps
 f_deb_autobake.addStep(steps.Compile(logfiles={'CMakeCache.txt': './builddir/CMakeCache.txt'}, command=["debian/autobake-deb.sh"],
     env={'CCACHE_DIR':'/mnt/ccache', 'DEB_BUILD_OPTIONS':util.Interpolate('parallel=%(kw:jobs)s', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))}, description="autobake-deb.sh"))
+# Check builded DEB files that they are following Lintian rules
+f_deb_autobake.addStep(steps.DebLintian(fileloc='../*.changes'))
 # upload binaries
 f_deb_autobake.addStep(steps.SetPropertyFromCommand(command="find .. -maxdepth 1 -type f", extract_fn=ls2string))
 #f_deb_autobake.addStep(steps.MultipleFileUpload(workersrcs=util.Property('packages'),


### PR DESCRIPTION
Add steps to Lintian build to make sure that builds are not violating Debian packaging rules