### PR TITLE
bb.org: bb-worker - add fc36

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -82,6 +82,9 @@ jobs:
           - dockerfile: fedora.Dockerfile
             image: fedora:35
             platforms: linux/amd64, linux/arm64/v8
+          - dockerfile: fedora.Dockerfile
+            image: fedora:36
+            platforms: linux/amd64, linux/arm64/v8
           - dockerfile: centos7.Dockerfile
             image: centos:7
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le

--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -93,7 +93,7 @@ jobs:
             platforms: linux/amd64, linux/arm64/v8
           - dockerfile: rhel7.Dockerfile
             image: rhel7
-            platforms: linux/amd64, linux/ppc64le
+            platforms: linux/amd64
           - dockerfile: rhel8.Dockerfile
             image: ubi8
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le

--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -87,7 +87,7 @@ jobs:
             platforms: linux/amd64, linux/arm64/v8
           - dockerfile: centos7.Dockerfile
             image: centos:7
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
+            platforms: linux/amd64
           - dockerfile: centos.Dockerfile
             image: quay.io/centos/centos:stream8
             platforms: linux/amd64, linux/arm64/v8

--- a/buildbot.mariadb.org/ci_build_images/fedora.Dockerfile
+++ b/buildbot.mariadb.org/ci_build_images/fedora.Dockerfile
@@ -43,12 +43,14 @@ RUN dnf -y upgrade \
     unixODBC \
     unixODBC-devel \
     wget \
-    && if [ "$(uname -m)" = "x86_64" ]; then dnf -y install libpmem-devel; fi \
+    && arch=$(uname -m) \
+    && if [ "$arch" = x86_64 ] || [ "$arch" = ppc64le ]; then dnf -y install libpmem-devel; fi \
     && dnf clean all \
-    && case $(uname -m) in \
+    && case $arch in \
         "x86_64") curl -sL "https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64" >/usr/local/bin/gosu ;; \
         "aarch64") curl -sL "https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64" >/usr/local/bin/gosu ;; \
         "ppc64le") curl -sL "https://github.com/tianon/gosu/releases/download/1.14/gosu-ppc64el" >/usr/local/bin/gosu ;; \
+        *) curl -sL "https://github.com/tianon/gosu/releases/download/1.14/gosu-$arch" >/usr/local/bin/gosu ;; \
     esac \
     && chmod +x /usr/local/bin/gosu
 


### PR DESCRIPTION
Also add libpmem as a ppc64le package based on
https://koji.fedoraproject.org/koji/buildinfo?buildID=1945661

Works on at least fc36.

Total download size: 253 k
Installed size: 949 k
Downloading Packages:
(1/4): daxctl-libs-73-1.fc36.ppc64le.rpm         60 kB/s |  42 kB     00:00
(2/4): libpmem-1.11.1-4.fc36.ppc64le.rpm         90 kB/s |  66 kB     00:00
(3/4): libpmem-devel-1.11.1-4.fc36.ppc64le.rpm   69 kB/s |  51 kB     00:00
(4/4): ndctl-libs-73-1.fc36.ppc64le.rpm         459 kB/s |  95 kB     00:00
--------------------------------------------------------------------------------

Make fedora's Dockerfile more portable to other arches as the need comes
up.