### PR TITLE
Remove cleanup that is not needed

### DIFF
--- a/buildbot.mariadb.org/common_factories.py
+++ b/buildbot.mariadb.org/common_factories.py
@@ -53,7 +53,6 @@ def getQuickBuildFactory(mtrDbPool):
     f_quick_build.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary", doStepIf=savePackage))
     f_quick_build.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
     f_quick_build.addStep(steps.Trigger(name='eco', schedulerNames=['s_eco'], waitForFinish=False, updateSourceStamp=False, set_properties={"parentbuildername": Property("buildername"), "tarbuildnum" : Property("tarbuildnum"), "mariadb_binary": Property("mariadb_binary"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch"), "parentbuildername": Property("buildername")}, doStepIf=lambda step: savePackage(step) and hasEco(step)))
-    f_quick_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
     return f_quick_build
 
 def getRpmAutobakeFactory(mtrDbPool):
@@ -98,6 +97,5 @@ def getRpmAutobakeFactory(mtrDbPool):
         set_properties={"tarbuildnum" : Property("tarbuildnum"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch"), "parentbuildername": Property("buildername")}, doStepIf=lambda step: hasInstall(step) and savePackage(step) and hasFiles(step)))
     f_rpm_autobake.addStep(steps.Trigger(name='major-minor-upgrade', schedulerNames=['s_upgrade'], waitForFinish=True, updateSourceStamp=False,
         set_properties={"tarbuildnum" : Property("tarbuildnum"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch"), "parentbuildername": Property("buildername")}, doStepIf=lambda step: hasUpgrade(step) and savePackage(step) and hasFiles(step)))
-    f_rpm_autobake.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
     return f_rpm_autobake
 

--- a/buildbot.mariadb.org/master-galera/master.cfg
+++ b/buildbot.mariadb.org/master-galera/master.cfg
@@ -352,7 +352,6 @@ f_deb_build.addStep(steps.ShellCommand(name='build packages', command=["bash", "
 ./scripts/build.sh -p""")], workdir='build'))
 f_deb_build.addStep(dpkgDeb())
 f_deb_build.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:branch)s' + '/' + '%(prop:revision)s' + '/' + '%(prop:buildername)s'+ ' && cp -r debs/ sha256sums.txt /packages/' + '%(prop:branch)s' + '/' + '%(prop:revision)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:branch)s' + '/' + '%(prop:revision)s'), doStepIf=lambda step: savePackage(step)))
-f_deb_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_rpm_build - create source tarball
 f_rpm_build = util.BuildFactory()
@@ -367,7 +366,6 @@ f_rpm_build.addStep(steps.GitHub(
 f_rpm_build.addStep(steps.ShellCommand(name='build packages', command=["bash", "-xc", "./scripts/build.sh -p"], workdir='build'))
 f_rpm_build.addStep(rpmSave())
 f_rpm_build.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:branch)s' + '/' + '%(prop:revision)s' + '/' + '%(prop:buildername)s'+ ' && cp -r rpms srpms sha256sums.txt' + ' /packages/' + '%(prop:branch)s' + '/' + '%(prop:revision)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:branch)s' + '/' + '%(prop:revision)s'), doStepIf=lambda step: savePackage(step)))
-f_rpm_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ####### LOCKS
 

--- a/buildbot.mariadb.org/master-libvirt/master.cfg
+++ b/buildbot.mariadb.org/master-libvirt/master.cfg
@@ -204,28 +204,24 @@ f_deb_install.addStep(getScript('deb-install.sh'))
 f_deb_install.addStep(getDebInstallStep())
 f_deb_install.addStep(getScript('deb-galera.sh'))
 f_deb_install.addStep(getDebGaleraStep("2223"))
-f_deb_install.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_deb_major_upgrade
 f_deb_major_upgrade = util.BuildFactory()
 f_deb_major_upgrade.addStep(steps.SetPropertyFromCommand(name="major_version", property="major_version", command=util.Interpolate("sh -c \"echo '%(prop:branch)s' | sed -e \\\"s/.*\\\\(5\\\\.5\\\\|10\\\\.[0-9]\\\\).*/\\\\1/\\\"\"")))
 f_deb_major_upgrade.addStep(getScript('deb-upgrade.sh'))
 f_deb_major_upgrade.addStep(getDebMajorUpgradeStep())
-f_deb_major_upgrade.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_deb_minor_upgrade
 f_deb_minor_upgrade = util.BuildFactory()
 f_deb_minor_upgrade.addStep(steps.SetPropertyFromCommand(name="major_version", property="major_version", command=util.Interpolate("sh -c \"echo '%(prop:branch)s' | sed -e \\\"s/.*\\\\(5\\\\.5\\\\|10\\\\.[0-9]\\\\).*/\\\\1/\\\"\"")))
 f_deb_minor_upgrade.addStep(getScript('deb-upgrade.sh'))
 f_deb_minor_upgrade.addStep(getDebMinorUpgradeStep())
-f_deb_minor_upgrade.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_rpm_install
 f_rpm_install = util.BuildFactory()
 f_rpm_install.addStep(downloadRpms())
 f_rpm_install.addStep(getScript('rpm-install.sh'))
 f_rpm_install.addStep(getRpmInstallStep())
-f_rpm_install.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_rpm_upgrade
 f_rpm_upgrade = util.BuildFactory()
@@ -233,7 +229,6 @@ f_rpm_upgrade.addStep(steps.SetPropertyFromCommand(name="major_version", propert
 f_rpm_upgrade.addStep(downloadRpms())
 f_rpm_upgrade.addStep(getScript('rpm-upgrade.sh'))
 f_rpm_upgrade.addStep(getRpmUpgradeStep())
-f_rpm_upgrade.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ####### BUILDERS LIST
 c['builders'] = []

--- a/buildbot.mariadb.org/master.cfg
+++ b/buildbot.mariadb.org/master.cfg
@@ -498,7 +498,6 @@ f_tarball.addStep(steps.ShellSequence( commands=[
 #f_tarball.addStep(steps.ShellSequence( commands=[
 #    util.ShellArg(command=util.Interpolate("git checkout " + "%(prop:staging_branch)s"), logfile="rebase"),
 #    util.ShellArg(command=util.Interpolate("git merge %(prop:branch)s"), logfile="rebase")], workdir="build/server", haltOnFailure="true", doStepIf=ifStagingSucceeding))
-f_tarball.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_32b_quick_build
 f_32b_quick_build = util.BuildFactory()
@@ -517,7 +516,6 @@ f_32b_quick_build.addStep(steps.DirectoryUpload(name="save mysqld log files", co
 # create package and upload to master
 f_32b_quick_build.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary"))
 #f_32b_quick_build.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
-f_32b_quick_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_asan_build
 f_asan_build = util.BuildFactory()
@@ -534,7 +532,6 @@ f_asan_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}
     ["sh", "-c", util.Interpolate('cd mysql-test && MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=`pwd`/lsan.supp" perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
 f_asan_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
 f_asan_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
-f_asan_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_msan_build
 f_msan_build = util.BuildFactory()
@@ -550,7 +547,6 @@ f_msan_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}
     ["bash", "-xc", util.Interpolate('cd mysql-test && LD_LIBRARY_PATH=/msan-libs MSAN_OPTIONS=abort_on_error=1 ./mtr --mem --big-test --force --retry=0 --skip-test=.*compression.* --max-test-fail=100 --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
 f_msan_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
 f_msan_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
-f_msan_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_valgrind_build
 f_valgrind_build = util.BuildFactory()
@@ -565,7 +561,6 @@ f_valgrind_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.ht
     ["sh", "-c", util.Interpolate('cd mysql-test && perl mysql-test-run.pl --valgrind="--leak-check=summary --gen-suppressions=yes --num-callers=10" --skip-test=encryption*  --force --retry=0 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
 f_valgrind_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
 f_valgrind_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
-f_valgrind_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_big_test
 f_big_test = util.BuildFactory()
@@ -585,7 +580,6 @@ f_big_test.addStep(steps.DirectoryUpload(name="save mysqld log files", compress=
 # create package and upload to master
 f_big_test.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary"))
 #f_big_test.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
-f_big_test.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_full_test
 f_full_test = util.BuildFactory()
@@ -609,7 +603,6 @@ f_full_test.addStep(steps.MTR(addLogs=True, name="test xtra", command=
     ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --suite=funcs_1,funcs_2,stress,jp --big --testcase-timeout=120 --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
 f_full_test.addStep(steps.MTR(addLogs=True, name="test engines", command=
     ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --suite=spider,spider/bg,engines/funcs,engines/iuds --big --testcase-timeout=120 --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
-f_full_test.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_deb_autobake
 f_deb_autobake = util.BuildFactory()
@@ -640,7 +633,6 @@ f_deb_autobake.addStep(steps.Trigger(name='galera-sst-rsync', schedulerNames=['s
     set_properties={"tarbuildnum" : Property("tarbuildnum"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch"), "parentbuildername": Property("buildername"), "sst_mode": "rsync"}, doStepIf=lambda step: hasInstall(step) and savePackage(step) and hasFiles(step)))
 f_deb_autobake.addStep(steps.Trigger(name='major-minor-upgrade', schedulerNames=['s_upgrade'], waitForFinish=True, updateSourceStamp=False,
     set_properties={"tarbuildnum" : Property("tarbuildnum"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch"), "parentbuildername": Property("buildername")}, doStepIf=lambda step: hasUpgrade(step) and savePackage(step) and hasFiles(step)))
-f_deb_autobake.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_bintar
 f_bintar = util.BuildFactory()
@@ -658,7 +650,6 @@ f_bintar.addStep(steps.Compile(command=
 # create package and upload to master
 f_bintar.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary", doStepIf=savePackage))
 f_bintar.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
-f_bintar.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_without_server
 f_without_server = util.BuildFactory()
@@ -676,7 +667,6 @@ f_without_server.addStep(steps.Compile(command=
 f_without_server.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary"))
 #f_without_server.addStep(steps.FileUpload(workersrc=util.Interpolate("%(prop:mariadb_binary)s"), masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + "/" + '%(prop:buildername)s' + "/" + "%(prop:mariadb_binary)s"), mode=0o755, url=util.Interpolate('https://ci.mariadb.org/' + "%(prop:tarbuildnum)s" + "/" + '%(prop:buildername)s' + "/"), urlText="Download", doStepIf=savePackage))
 f_without_server.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
-f_without_server.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_eco_php
 f_eco_php = util.BuildFactory()


### PR DESCRIPTION
The cleanup command is useless:
- docker container are not reused
- libvirt VM are always clean (qemu hook)

@vladbogo I am not sure about nonlatent workers but we probably only need the cleanup step for them?