### PR TITLE
Master libvirt

### DIFF
--- a/buildbot.mariadb.org/constants.py
+++ b/buildbot.mariadb.org/constants.py
@@ -1,14 +1,71 @@
-github_status_builders = ["amd64-centos-7", "amd64-debian-10", "amd64-fedora-35", "amd64-ubuntu-2004-clang11", "amd64-ubuntu-2004-debug", "amd64-windows"]
+import yaml
 
-release_builders = ["aarch64-centos-7", "aarch64-centos-7-rpm-autobake", "aarch64-debian-9", "aarch64-debian-9-deb-autobake", "aarch64-debian-10", "aarch64-debian-10-deb-autobake", "aarch64-debian-11", "aarch64-debian-11-deb-autobake", "aarch64-debian-sid", "aarch64-debian-sid-deb-autobake", "aarch64-fedora-34", "aarch64-fedora-34-rpm-autobake", "aarch64-fedora-35", "aarch64-fedora-35-rpm-autobake", "aarch64-rhel-8", "aarch64-rhel-8-rpm-autobake", "aarch64-ubuntu-1804", "aarch64-ubuntu-1804-deb-autobake", "aarch64-ubuntu-2110", "aarch64-ubuntu-2110-deb-autobake", "aarch64-ubuntu-2004", "aarch64-ubuntu-2004-deb-autobake", "amd64-debian-sid", "amd64-debian-sid-deb-autobake", "ppc64le-debian-11", "ppc64le-debian-11-deb-autobake", "ppc64le-debian-sid", "ppc64le-debian-sid-deb-autobake", "s390x-ubuntu-2004", "s390x-ubuntu-2004-deb-autobake", "s390x-ubuntu-2204", "s390x-ubuntu-2204-deb-autobake", "s390x-rhel-8", "s390x-rhel-8-rpm-autobake", "s390x-sles-15", "s390x-sles-15-rpm-autobake"]
+with open('/srv/buildbot/mariadb.org-tools/buildbot.mariadb.org/os_info.yaml', 'r') as f:
+    os_info = yaml.safe_load(f)
+
+github_status_builders = [
+        "amd64-centos-7",
+        "amd64-debian-10",
+        "amd64-fedora-35",
+        "amd64-ubuntu-2004-clang11",
+        "amd64-ubuntu-2004-debug",
+        "amd64-windows",
+        ]
+
+release_builders = [
+        "aarch64-centos-7",
+        "aarch64-centos-7-rpm-autobake",
+        "aarch64-debian-9",
+        "aarch64-debian-9-deb-autobake",
+        "aarch64-debian-10",
+        "aarch64-debian-10-deb-autobake",
+        "aarch64-debian-11",
+        "aarch64-debian-11-deb-autobake",
+        "aarch64-debian-sid",
+        "aarch64-debian-sid-deb-autobake",
+        "aarch64-fedora-34",
+        "aarch64-fedora-34-rpm-autobake",
+        "aarch64-fedora-35",
+        "aarch64-fedora-35-rpm-autobake",
+        "aarch64-rhel-8",
+        "aarch64-rhel-8-rpm-autobake",
+        "aarch64-ubuntu-1804",
+        "aarch64-ubuntu-1804-deb-autobake",
+        "aarch64-ubuntu-2110",
+        "aarch64-ubuntu-2110-deb-autobake",
+        "aarch64-ubuntu-2004",
+        "aarch64-ubuntu-2004-deb-autobake",
+        "amd64-debian-sid",
+        "amd64-debian-sid-deb-autobake",
+        "ppc64le-debian-11",
+        "ppc64le-debian-11-deb-autobake",
+        "ppc64le-debian-sid",
+        "ppc64le-debian-sid-deb-autobake",
+        "s390x-ubuntu-2004",
+        "s390x-ubuntu-2004-deb-autobake",
+        "s390x-ubuntu-2204",
+        "s390x-ubuntu-2204-deb-autobake",
+        "s390x-rhel-8",
+        "s390x-rhel-8-rpm-autobake",
+        "s390x-sles-15",
+        "s390x-sles-15-rpm-autobake",
+        ]
 
 builders_autobake=["amd64-centos-7-rpm-autobake", "amd64-centos-stream8-rpm-autobake", "amd64-debian-9-deb-autobake", "x86-debian-9-deb-autobake", "amd64-debian-10-deb-autobake", "amd64-debian-11-deb-autobake", "amd64-debian-sid-deb-autobake", "x86-debian-sid-deb-autobake", "amd64-fedora-34-rpm-autobake", "amd64-fedora-35-rpm-autobake", "amd64-rhel-7-rpm-autobake", "amd64-rhel-8-rpm-autobake", "amd64-opensuse-15-rpm-autobake", "amd64-sles-12-rpm-autobake", "amd64-sles-15-rpm-autobake", "amd64-ubuntu-1804-deb-autobake", "amd64-ubuntu-2004-deb-autobake", "amd64-ubuntu-2110-deb-autobake", "amd64-ubuntu-2204-deb-autobake", "aarch64-ubuntu-1804-deb-autobake", "aarch64-ubuntu-2004-deb-autobake", "aarch64-ubuntu-2204-deb-autobake", "aarch64-ubuntu-2110-deb-autobake", "ppc64le-debian-9-deb-autobake", "ppc64le-debian-10-deb-autobake", "ppc64le-debian-11-deb-autobake", "ppc64le-debian-sid-deb-autobake", "ppc64le-ubuntu-1804-deb-autobake", "ppc64le-ubuntu-2004-deb-autobake", "ppc64le-ubuntu-2110-deb-autobake", "ppc64le-ubuntu-2204-deb-autobake", "ppc64le-centos-7-rpm-autobake", "ppc64le-rhel-7-rpm-autobake", "ppc64le-rhel-8-rpm-autobake", "aarch64-debian-10-deb-autobake", "aarch64-debian-11-deb-autobake", "aarch64-debian-sid-deb-autobake", "aarch64-debian-9-deb-autobake", "aarch64-fedora-34-rpm-autobake", "aarch64-fedora-35-rpm-autobake", "aarch64-centos-7-rpm-autobake", "aarch64-centos-8-rpm-autobake", "aarch64-rhel-7-rpm-autobake", "aarch64-rhel-8-rpm-autobake", "s390x-ubuntu-2004-deb-autobake", "s390x-ubuntu-2204-deb-autobake", "s390x-rhel-8-rpm-autobake", "s390x-sles-15-rpm-autobake"]
 
 builders_big=["amd64-ubuntu-1804-bigtest"]
 
-builders_install=["amd64-debian-11-deb-autobake-install", "amd64-ubuntu-1804-deb-autobake-install", "amd64-centos-7-rpm-autobake-install", "amd64-fedora-35-rpm-autobake-install"]
-
-builders_upgrade=["amd64-ubuntu-1804-deb-autobake-major-upgrade", "amd64-ubuntu-1804-deb-autobake-minor-upgrade", "amd64-centos-7-rpm-autobake-major-upgrade", "amd64-centos-7-rpm-autobake-minor-upgrade"]
+# Generate install builders based on the os_info data
+builders_install = []
+builders_upgrade = []
+for os in os_info:
+    for arch in os_info[os]['arch']:
+        builder_name_install = arch + '-' + os + '-' + os_info[os]['type'] + '-autobake-install'
+        builders_install.append(builder_name_install)
+        builder_name_minor_upgrade = arch + '-' + os + '-' + os_info[os]['type'] + '-autobake-minor-upgrade'
+        builders_upgrade.append(builder_name_minor_upgrade)
+        builder_name_major_upgrade = arch + '-' + os + '-' + os_info[os]['type'] + '-autobake-major-upgrade'
+        builders_upgrade.append(builder_name_major_upgrade)
 
 builders_eco=["amd64-ubuntu-2004-eco-php", "amd64-debian-10-eco-pymysql", "amd64-debian-10-eco-mysqljs", "amd64-ubuntu-2004-eco-dbdeployer"]
 

--- a/buildbot.mariadb.org/master-libvirt/master.cfg
+++ b/buildbot.mariadb.org/master-libvirt/master.cfg
@@ -58,39 +58,7 @@ c['db'] = {
 ####### Disable net usage reports from being sent to buildbot.net
 c['buildbotNetUsageData'] = None
 
-####### WORKERS
-
-# The 'workers' list defines the set of recognized workers. Each element is
-# a Worker object, specifying a unique worker name and password.  The same
-# worker name and password must be configured on the worker.
-c['workers'] = []
-
-# LibVirt workers
-c['workers'].append(worker.LibVirtWorker('bb-hz-bbw5-debian-11',
-                    config["private"]["worker_pass"]["libvirt"],
-                    util.Connection('qemu+ssh://buildbot@100.64.100.20:65001/system'),
-                    '/var/lib/libvirt/images/bb-hz-bbw5-debian-11', build_wait_timeout=0, max_builds=1))
-
-c['workers'].append(worker.LibVirtWorker('bb-hz-bbw5-ubuntu-1804',
-                    config["private"]["worker_pass"]["libvirt"],
-                    util.Connection('qemu+ssh://buildbot@100.64.100.20:65001/system'),
-                    '/var/lib/libvirt/images/bb-hz-bbw5-ubuntu-1804', build_wait_timeout=0, max_builds=1))
-
-c['workers'].append(worker.LibVirtWorker('bb-hz-bbw5-fedora-35',
-                    config["private"]["worker_pass"]["libvirt"],
-                    util.Connection('qemu+ssh://buildbot@100.64.100.20:65001/system'),
-                    '/var/lib/libvirt/images/bb-hz-bbw5-fedora-35', build_wait_timeout=0, max_builds=1))
-
-c['workers'].append(worker.LibVirtWorker('bb-hz-bbw5-centos-7',
-                    config["private"]["worker_pass"]["libvirt"],
-                    util.Connection('qemu+ssh://buildbot@100.64.100.20:65001/system'),
-                    '/var/lib/libvirt/images/bb-hz-bbw5--centos-7', build_wait_timeout=0, max_builds=1))
-
-####### BUILDERS
-
-# The 'builders' list defines the Builders, which tell Buildbot how to perform a build:
-# what steps, and which workers can execute them.  Note that any particular build will
-# only take place on one worker.
+####### UTILS
 
 def downloadRpms():
     return ShellCommand(
@@ -169,16 +137,7 @@ def getDebGaleraStep(port):
         command=["./deb-galera.sh"]
     )
 
-def getDebMinorUpgradeStep():
-    return Test(
-        name="upgrade",
-        haltOnFailure=True,
-        description=["testing", "upgrade"],
-        descriptionDone=["test", "upgrade"],
-        env=envFromProperties(['test_mode', 'test_type', 'branch', 'master_branch', 'arch', 'dist_name', 'version_name', 'mariadb_version', 'major_version', 'systemdCapability', 'needsGalera', 'parentbuildername']),
-        command=['./deb-upgrade.sh'])
-
-def getDebMajorUpgradeStep():
+def getDebUpgradeStep():
     return Test(
         name="upgrade",
         haltOnFailure=True,
@@ -204,28 +163,18 @@ f_deb_install.addStep(getScript('deb-install.sh'))
 f_deb_install.addStep(getDebInstallStep())
 f_deb_install.addStep(getScript('deb-galera.sh'))
 f_deb_install.addStep(getDebGaleraStep("2223"))
-f_deb_install.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
-## f_deb_major_upgrade
-f_deb_major_upgrade = util.BuildFactory()
-f_deb_major_upgrade.addStep(steps.SetPropertyFromCommand(name="major_version", property="major_version", command=util.Interpolate("sh -c \"echo '%(prop:branch)s' | sed -e \\\"s/.*\\\\(5\\\\.5\\\\|10\\\\.[0-9]\\\\).*/\\\\1/\\\"\"")))
-f_deb_major_upgrade.addStep(getScript('deb-upgrade.sh'))
-f_deb_major_upgrade.addStep(getDebMajorUpgradeStep())
-f_deb_major_upgrade.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
-
-## f_deb_minor_upgrade
-f_deb_minor_upgrade = util.BuildFactory()
-f_deb_minor_upgrade.addStep(steps.SetPropertyFromCommand(name="major_version", property="major_version", command=util.Interpolate("sh -c \"echo '%(prop:branch)s' | sed -e \\\"s/.*\\\\(5\\\\.5\\\\|10\\\\.[0-9]\\\\).*/\\\\1/\\\"\"")))
-f_deb_minor_upgrade.addStep(getScript('deb-upgrade.sh'))
-f_deb_minor_upgrade.addStep(getDebMinorUpgradeStep())
-f_deb_minor_upgrade.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
+## f_deb_upgrade
+f_deb_upgrade = util.BuildFactory()
+f_deb_upgrade.addStep(steps.SetPropertyFromCommand(name="major_version", property="major_version", command=util.Interpolate("sh -c \"echo '%(prop:branch)s' | sed -e \\\"s/.*\\\\(5\\\\.5\\\\|10\\\\.[0-9]\\\\).*/\\\\1/\\\"\"")))
+f_deb_upgrade.addStep(getScript('deb-upgrade.sh'))
+f_deb_upgrade.addStep(getDebUpgradeStep())
 
 ## f_rpm_install
 f_rpm_install = util.BuildFactory()
 f_rpm_install.addStep(downloadRpms())
 f_rpm_install.addStep(getScript('rpm-install.sh'))
 f_rpm_install.addStep(getRpmInstallStep())
-f_rpm_install.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_rpm_upgrade
 f_rpm_upgrade = util.BuildFactory()
@@ -233,90 +182,103 @@ f_rpm_upgrade.addStep(steps.SetPropertyFromCommand(name="major_version", propert
 f_rpm_upgrade.addStep(downloadRpms())
 f_rpm_upgrade.addStep(getScript('rpm-upgrade.sh'))
 f_rpm_upgrade.addStep(getRpmUpgradeStep())
-f_rpm_upgrade.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
-####### BUILDERS LIST
+####### WORKERS and BUILDERS
+
+# The 'workers' list defines the set of recognized workers. Each element is
+# a Worker object, specifying a unique worker name and password.  The same
+# worker name and password must be configured on the worker.
+c['workers'] = []
 c['builders'] = []
 
-c['builders'].append(
-    util.BuilderConfig(name="amd64-debian-11-deb-autobake-install",
-      workernames=["bb-hz-bbw5-debian-11"],
-      tags=["Ubuntu", "deb", "install", "kvm"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      properties={'systemdCapability': 'yes', 'needsGalera': 'yes', 'dist_name': 'debian', 'version_name': 'bullseye', 'arch': 'amd64'},
-      factory=f_deb_install))
+# Add the workers and builds based on the configured install builders (see constants.py)
+for builder_name in builders_install:
+    # Parse builder name
+    platform, os_name, os_version, builder_type = builder_name.split('-')[:4]
 
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804-deb-autobake-install",
-      workernames=["bb-hz-bbw5-ubuntu-1804"],
-      tags=["Ubuntu", "deb", "install", "kvm"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      properties={'systemdCapability': 'yes', 'needsGalera': 'yes', 'dist_name': 'ubuntu', 'version_name': 'bionic', 'arch': 'amd64'},
-      factory=f_deb_install))
+    assert builder_type in ['rpm', 'deb']
+    assert platform in ['amd64', 'aarch64']
 
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804-deb-autobake-major-upgrade",
-      workernames=["bb-hz-bbw5-ubuntu-1804"],
-      tags=["Ubuntu", "deb", "upgrade", "kvm"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      properties={'systemdCapability': 'yes', 'needsGalera': 'yes', 'dist_name': 'ubuntu', 'version_name': 'bionic', 'arch': 'amd64', 'test_mode': 'server', "test_type": "major"},
-      factory=f_deb_major_upgrade))
+    os_info_name = os_name + '-' + os_version
 
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804-deb-autobake-minor-upgrade",
-      workernames=["bb-hz-bbw5-ubuntu-1804"],
-      tags=["Ubuntu", "deb", "upgrade", "kvm"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      properties={'systemdCapability': 'yes', 'needsGalera': 'yes', 'dist_name': 'ubuntu', 'version_name': 'bionic', 'arch': 'amd64', 'test_mode': 'all', "test_type": "minor"},
-      factory=f_deb_minor_upgrade))
+    libvirt_worker_name = config['private']['libvirt_workers'][platform][0] + '-' + os_name + '-' + os_version
+    connection_url = config['private']['libvirt_workers'][platform][1]
+    image_path = '/var/libvirt/images/' + libvirt_worker_name
 
-c['builders'].append(
-    util.BuilderConfig(name="amd64-centos-7-rpm-autobake-install",
-      workernames=["bb-hz-bbw5-centos-7"],
-      tags=["Centos", "rpm", "install"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      properties={'systemdCapability': 'yes', 'needsGalera': 'yes', 'version_name': '7', 'arch': 'centos74-amd64'},
-      factory=f_rpm_install))
+    c['workers'].append(worker.LibVirtWorker(libvirt_worker_name,
+        config["private"]["worker_pass"]["libvirt"],
+        util.Connection(connection_url),
+        image_path, build_wait_timeout=0, max_builds=1))
 
-c['builders'].append(
-    util.BuilderConfig(name="amd64-centos-7-rpm-autobake-major-upgrade",
-      workernames=["bb-hz-bbw5-centos-7"],
-      tags=["Centos", "rpm", "upgrade"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      properties={'systemdCapability': 'yes', 'needsGalera': 'yes', 'version_name': 'centos7', 'arch': 'amd64', "test_type": "major", "test_mode": "server"},
-      factory=f_rpm_upgrade))
+    if builder_type == 'deb':
+        factory_install = f_deb_install
+        factory_upgrade = f_deb_upgrade
+        build_arch = platform
+    elif builder_type == 'rpm':
+        factory_install = f_rpm_install
+        factory_upgrade = f_rpm_upgrade
+        build_arch = os_name + os_version + '-' + platform
 
-c['builders'].append(
-    util.BuilderConfig(name="amd64-centos-7-rpm-autobake-minor-upgrade",
-      workernames=["bb-hz-bbw5-centos-7"],
-      tags=["Centos", "rpm", "upgrade"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      properties={'systemdCapability': 'yes', 'needsGalera': 'yes', 'version_name': 'centos7', 'arch': 'amd64', "test_type": "minor", "test_mode": "server"},
-      factory=f_rpm_upgrade))
+    c['builders'].append(
+        util.BuilderConfig(name=builder_name,
+            workernames=libvirt_worker_name,
+            tags=[os_name, builder_type, 'install', 'kvm'],
+            collapseRequests=True,
+            nextBuild=nextBuild,
+            canStartBuild=canStartBuild,
+            properties={
+                'systemdCapability': 'yes',
+                'needsGalera': 'yes',
+                'dist_name': os_name,
+                'version_name': os_info[os_info_name]['version_name'],
+                'arch': build_arch,
+                'BB_CI': True,
+                },
+            factory=factory_install))
 
-c['builders'].append(
-    util.BuilderConfig(name="amd64-fedora-35-rpm-autobake-install",
-      workernames=["bb-hz-bbw5-fedora-35"],
-      tags=["Fedora", "rpm", "install"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      properties={'systemdCapability': 'yes', 'needsGalera': 'yes', 'version_name': '35', 'arch': 'fedora35-amd64'},
-      factory=f_rpm_install))
+    # Add major upgrade builder
+    major_upgrade_name = '-'.join(builder_name.split('-')[:5]) + '-major-upgrade'
+
+    c['builders'].append(
+        util.BuilderConfig(name=major_upgrade_name,
+          workernames=libvirt_worker_name,
+          tags=[os_name, builder_type, 'upgrade', 'kvm'],
+          collapseRequests=True,
+          nextBuild=nextBuild,
+          canStartBuild=canStartBuild,
+          properties={
+              'systemdCapability': 'yes', 
+              'needsGalera': 'yes', 
+              'dist_name': os_name, 
+              'version_name': os_info[os_info_name]['version_name'],
+              'arch': build_arch, 
+              'test_mode': 'server', 
+              'test_type': 'major',
+              'BB_CI': True,
+             },
+          factory=factory_upgrade))
+
+    # Add minor upgrade builder
+    minor_upgrade_name = '-'.join(builder_name.split('-')[:5]) + '-minor-upgrade'
+
+    c['builders'].append(
+        util.BuilderConfig(name=minor_upgrade_name,
+          workernames=libvirt_worker_name,
+          tags=[os_name, builder_type, 'upgrade', 'kvm'],
+          collapseRequests=True,
+          nextBuild=nextBuild,
+          canStartBuild=canStartBuild,
+          properties={
+              'systemdCapability': 'yes', 
+              'needsGalera': 'yes', 
+              'dist_name': os_name, 
+              'version_name': os_info[os_info_name]['version_name'],
+              'arch': build_arch,
+              'test_mode': 'server', 
+              'test_type': "minor",
+              'BB_CI': True,
+              },
+          factory=factory_upgrade))
 
 c['logEncoding'] = 'utf-8'
 

--- a/buildbot.mariadb.org/master-libvirt/watchdog_libvirt.sh
+++ b/buildbot.mariadb.org/master-libvirt/watchdog_libvirt.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# When the libvirt master starts, it creates an ssh connection to the worker
+# machine for each defined worker. If for any reason that ssh connection drops
+# (for example on a restart of the libvirtd daemon), then there will be build
+# failures because workers are no more available. The master doesn't handle at
+# all this and a master restart is needed.
+# See: https://jira.mariadb.org/browse/MDBF-415
+
+# This needs to be called as ExecStartPost= in the systemd unit file.
+# See: /etc/systemd/system/buildbot-master-libvirt.service
+
+watchdog() {
+  VAR_BB_LIBVIRT_DIR="/srv/buildbot/master/master-libvirt"
+  VAR_BB_LIBVIRT_CONF="$VAR_BB_LIBVIRT_DIR/master.cfg"
+
+  while true; do
+    FAIL=0
+    VAR_QEMU_SSH_CONF=7
+    # shellcheck disable=SC2009
+    VAR_QEMU_SSH_CONNEXION=$(ps faux | grep -c "qemu:///")
+
+    if ((VAR_QEMU_SSH_CONF != $((VAR_QEMU_SSH_CONNEXION - 1)))); then
+      FAIL=1
+    fi
+
+    if ((FAIL == 0)); then
+      /bin/systemd-notify WATCHDOG=1;
+      sleep $((WATCHDOG_USEC / 2000000))
+    else
+      sleep 1
+    fi
+  done
+}
+
+watchdog &

--- a/buildbot.mariadb.org/os_info.yaml
+++ b/buildbot.mariadb.org/os_info.yaml
@@ -1,0 +1,23 @@
+debian-11:
+  version_name: bullseye
+  arch:
+    - amd64
+    - aarch64
+  type: deb
+ubuntu-1804:
+  version_name: bionic
+  arch:
+    - amd64
+    - aarch64
+  type: deb
+centos-7:
+  version_name: 7
+  arch:
+    - amd64
+  type: rpm
+fedora-35:
+  version_name: 35
+  arch:
+    - amd64
+    - aarch64
+  type: rpm


### PR DESCRIPTION
Re-factor the code for the libvirt master to automatically generate the builders and workers.

What needs to be done:

> Fix the naming differences
> Do the same for upgrade