### PR TITLE
Add start of GitDM based metrics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "metrics/gitdm"]
+	path = metrics/gitdm
+	url = git://git.lwn.net/gitdm.git

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,15 +1,35 @@
 # Metrics Tools
 
-## get_prs.py
+## Commit Metrics
+
+We are using GitDM to process the git tree for MariaDB and generate metrics based on individuals and their affiliations. It pulls and process everything on the MariaDB tree so that commits to older branches (bug fixes) are counted.
+
+GitDM is configured using the files in the `gitdm_config` subdirectory. The key files here help determine which company a given individual email address works for, and alises between addresses. The files are as follows:
+
+#### domain-map
+
+This is a catchall for an email domain name to company mapping.
+
+#### aliases
+
+This contains a list of email addresses which are aliases to other email addresses.
+
+#### employers
+
+This contains a list of email addresses which do not fit into the above categories, such as personal email addresses or individuals, to determine a given contributor's affiliation.
+
+## PR Counts
+
+### get_prs.py
 
 This tool gets the PR counts for 2022 and stores them in `prs.csv`, if it is interrupted the current week number fetched is stored in `prs_start.txt` so it can continue. This also means that it can be run as a script and will only append as required when there is new data. There is a deliberate 2 second pause between each request so as not to hit the GitHub rate limit (30 requests per minute).
 
 To execute this you will need a GitHub token from https://github.com/settings/tokens/new and set this as the environment variable `GITHUB_TOKEN`.
 
-## plot_prs.py
+### plot_prs.py
 
 This plots the new open/closed statuses for each week, using data from the `prs.csv` file. It requires `matplotlib` and `numpy` Python packages are installed (both in standard distro packages and PyPi).
 
-## plot_totals.py
+### plot_totals.py
 
 This plots the total count of open/closed PRs for each week using the data from `prs.csv`. It also requires `matplotlib` and `numpy` Python packages.

--- a/metrics/TODO.md
+++ b/metrics/TODO.md
@@ -1,0 +1,17 @@
+# GITDM
+
+* Have the git retrieval code smart enough to do `pull --ff-only` if the local clone already exists.
+* Move some of the people in the employers list to the aliases list where possible (particularly MariaDB Corporation / Foundation staff).
+* Modify the shell script to be more flexible with regards to date ranges.
+* Generate CSV file outputs.
+* Using `-t` crashes.
+* Possibly change "Funky" output. Or at least add aliases for the funky entries.
+* Drop stats not relevant to us from output.
+* Fix cause of this message: `Skip big patch (2491788)`.
+* Add breakdown by area of codebase (individual engines).
+* Separate out individual contributors that contribute on behalf of OSes into another list (I think GroupMap might be useful here).
+
+# PRs
+
+* Allow script to accept custom date range inputs (week/month/year and start/stop).
+* Create generic custom plot function.

--- a/metrics/get_git_log.sh
+++ b/metrics/get_git_log.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+git submodule update --init
+git clone https://github.com/mariadb/server --no-tags
+cd server
+git log --all --numstat -M --since-as-filter="2019-01-01" --until="2020-01-01" > git-2019.log
+git log --all --numstat -M --since-as-filter="2020-01-01" --until="2021-01-01" > git-2020.log
+git log --all --numstat -M --since-as-filter="2021-01-01" --until="2022-01-01" > git-2021.log
+git log --all --numstat -M --since-as-filter="2022-01-01" --until="2023-01-01" > git-2022.log
+cd ..
+gitdm/gitdm -c gitdm_config/gitdm.config -u -n < server/git-2019.log > out-2019.txt
+gitdm/gitdm -c gitdm_config/gitdm.config -u -n < server/git-2020.log > out-2020.txt
+gitdm/gitdm -c gitdm_config/gitdm.config -u -n < server/git-2021.log > out-2021.txt
+gitdm/gitdm -c gitdm_config/gitdm.config -u -n < server/git-2022.log > out-2022.txt

--- a/metrics/gitdm_config/aliases
+++ b/metrics/gitdm_config/aliases
@@ -1,0 +1,30 @@
+# This is the email aliases file, mapping secondary addresses
+# onto a single, canonical address.
+#
+# Alias first, then the email address to link it to.
+# Attempting to keep it in alphabetical order based on first column.
+105884371+fluesvamp@users.noreply.github.com    askeblad@outlook.com
+46791326+rucha174@users.noreply.github.com      rucha.deodhar@mariadb.com
+61234003+mysqlonarm@users.noreply.github.com    mysqlonarm@gmail.com
+91733807+sergmariadb@users.noreply.github.com   sergeikrivonos@gmail.com
+abychko@gmail.com                               alexey.bychko@mariadb.com
+andrew@mariadb.org                              andrew@linuxjedi.co.uk
+bar@home.dlink                                  bar@mariadb.com
+chriscalender@gmail.com                         chris@mariadb.com
+git@darkain.com                                 github@darkain.com
+grooverdan@users.sourceforge.net                daniel@linux.ibm.com
+krunalbauskar@gmail.com                         mysqlonarm@gmail.com
+maghermit@maghermit.com                         vladkakurin007@gmail.com
+mkaruza@users.noreply.github.com                mario.karuza@galeracluster.com
+# NOTE: This might cause issues later, but for now it is the only person who did this
+name@localhost.localdomain                      sergeikrivonos@gmail.com
+nayuta.yanagisawa@gmail.com                     nayuta.yanagisawa@hey.com
+olegs@teramind.co                               olernov@gmail.com
+otto@debian.org                                 otto@kekalainen.net
+ruchad1998@gmail.com                            rucha.deodhar@mariadb.com
+sachinsetia1001@gmail.com                       sachin.setiya@mariadb.com
+serzh7214@mail,ru                               serzh7214@mail.ru
+sp1l@users.noreply.github.com                   brnrd@freebsd.org
+stepan@cnt7glr11.localdomain                    stepan.patryshev@mariadb.com
+tmokmss@users.noreply.github.com                tomookam@live.jp
+vicentiu@localhost.localdomain                  vicentiu@mariadb.org

--- a/metrics/gitdm_config/domain-map
+++ b/metrics/gitdm_config/domain-map
@@ -1,0 +1,49 @@
+# Here is a set of mappings of domain names onto employer names.
+
+alpinelinux.org     Alpine Linux
+amazon.com          Amazon
+appian.com          Appian
+askmonty.org        Monty Program < 2013-04-23
+askmonty.org        MariaDB Corporation
+arm.com             Arm
+artixlinux.org      Artix Linux
+atos.net            Atos
+clear-code.com      ClearCode
+clustrix.com        MariaDB Corporation
+codership.com       Codership
+fruct.org           FRUCT
+huawei.com          Huawei
+ibm.com             IBM
+jd.com              JD.com (Jingdong)
+kali.org            Kali Linux
+kitware.com         Kitware
+galeracluster.com   Codership
+m2mobi.com          M2Mobi
+mariadb.com         MariaDB Corporation
+mariadb.org         MariaDB Foundation
+montyprogram.com    Monty Program < 2013-04-23
+montyprogram.com    MariaDB Corporation
+mysql.com           MySQL < 2008-01-16
+mysql.com           Sun Microsystems < 2010-01-27
+mysql.com           Oracle Corporation
+nichi.com           Nichi-in
+omniosce.org        OmniOS
+oracle.com          Oracle Corporation
+percona.com         Percona
+redhat.com          RedHat
+scaleflux.com       ScaleFlux
+service-now.com     ServiceNow
+servicenow.com      ServiceNow
+skysql.com          SkySQL < 2013-04-23
+skysql.com          MariaDB Corporation
+sun.com             Sun Microsystems < 2010-01-27
+sun.com             Oracle Corporation
+suse.cz             SUSE Linux
+suse.de             SUSE Linux
+tempesta-tech.com   Tempesta
+tencent.com         Tencent
+tiledb.io           TileDB
+tokutek.com         Tokutek < 2015-04-14
+tokutek.com         Percona
+vettabase.com       Vettabase
+windriver.com       Wind River

--- a/metrics/gitdm_config/employers
+++ b/metrics/gitdm_config/employers
@@ -1,0 +1,159 @@
+# A mapping of email addresses to employers where the domain-map catchall
+# does not fit. Some of these could likely be put in the aliases map instead.
+# First column is the email address, second is the company. A date range at a
+# given company is supported, see andrew@linuxjedi.co.uk as an example.
+# Intention is to sort by first column.
+
+108760288+mariadb-LuisLizardo@users.noreply.github.com MariaDB Corporation
+344369869@qq.com                                    Independent
+35718816+GreaTdANie1@users.noreply.github.com       Tencent
+45011689+heckad@users.noreply.github.com            Independent
+526786050@qq.com                                    Independent
+55976466+yongxin-xu@users.noreply.github.com        Independent
+52912568+CodyBuilder-dev@users.noreply.github.com   Independent
+68223875+haomi123@users.noreply.github.com          Independent
+73822648+ryancaicse@users.noreply.github.com        Independent
+74543075+jesusaplsoftware@users.noreply.github.com  Independent
+84491488@qq.com                                     Independent
+875825800@qq.com                                    Independent
+A00279809@student.ait.ie                            Independent
+a2sin2a2ko@kyoto-y.work                             Independent
+a97410985new@gmail.com                              Independent
+AddisonG@users.noreply.github.com                   Independent
+ajb459684460@gmail.com                              Independent
+alan.cuevamr@gmail.com                              Independent
+alex.fan.q@gmail.com                                Gentoo
+alice.sherepa@gmail.com                             MariaDB Corporation
+andrew@linuxjedi.co.uk                              MariaDB Corporation < 2020-08-15
+andrew@linuxjedi.co.uk                              MariaDB Foundation
+angeloudy@gmail.com                                 Independent
+arkamar@atlas.cz                                    Gentoo
+askeblad@outlook.com                                Independent
+brnrd@freebsd.org                                   FreeBSD
+bertrandop@gmail.com                                Independent
+bluemrp9@gmail.com                                  Independent
+brad@comstyle.com                                   OpenBSD
+caribe@users.noreply.github.com                     Gruppo Mondadori (Mondadori Group)
+claprix@yandex.ru                                   MariaDB Corporation
+contact@leandropacheco.com                          Codership
+cvicentiu@gmail.com                                 MariaDB Foundation
+d8sk4ueum@gmail.com                                 Amazon
+daniel@linux.ibm.com                                IBM < 2020-07-14
+daniel@linux.ibm.com                                MariaDB Foundation
+daniel.nachun@gmail.com                             Independent
+dansolo@mail.ru                                     Independent
+db@dbart.us                                         MariaDB Corporation
+devnexen@gmail.com                                  Independent
+dominik.b.czarnota@gmail.com                        Trail of Bits
+eric@freesa.org                                     MariaDB Foundation
+eirinikos@gmail.com                                 Independent
+faustin@fala.red                                    MariaDB Foundation
+fxcoudert@gmail.com                                 Independent
+gagan.nith@gmail.com                                MariaDB Corporation
+geert@hendrickx.be                                  Independent
+geoff.montee@gmail.com                              MariaDB Corporation
+github@darkain.com                                  Independent
+github@greenman.co.za                               MariaDB Foundation
+h.hata.ai.t@gmail.com                               Independent
+hannu.hartikainen@gmail.com                         HiQ Finland
+hashirsarwarch@gmail.com                            Zulip
+hartmut@php.net                                     MariaDB Corporation
+heckad@yandex.ru                                    Independent
+hollowman@hollowman.ml                              Independent
+hygonsoc@gmail.com                                  Independent
+hzc989@outlook.com                                  Independent
+i@gxdvip.com                                        Independent
+i@waynest.com                                       Independent
+izhaoshuang@163.com                                 Independent
+jani.k.tolonen@gmail.com                            Independent
+jean@phpnet.org                                     Independent
+# Unsure on exact date
+ji@haidongji.com                                    Independent < 2022-05-01
+ji@haidongji.com                                    Amazon
+jonathan.sabbe@gmail.com                            Worldline Global
+jordy@pwning.systems                                Independent
+justin@jagieniak.net                                Independent
+karel.picman@kontron.com                            Kontron
+kituemr@gmail.com                                   Independent
+karmengc@gmail.com                                  Independent
+kartiksoneji@rocketmail.com                         Independent
+kazzix14@gmail.com                                  Independent
+# Unsure on exact date
+kentokushiba@gmail.com                              Independent < 2019-02-01
+kentokushiba@gmail.com                              MariaDB Corporation
+kohei-matsuyama@users.noreply.github.com            Independent
+kuleshovmail@gmail.com                              Independent
+# Unsure on exact dates
+laurynas.biveinis@gmail.com                         Percona < 2011-03-01
+laurynas.biveinis@gmail.com                         Aerospike < 2022-01-01
+laurynas.biveinis@gmail.com                         VilniusDB
+lewart3@gmail.com                                   Independent
+likemartinma@gmail.com                              Scutech Corporation
+lingbinlb@gmail.com                                 Baidu
+liuruoji@gmail.com                                  Huawei
+lovelgw@gmail.com                                   Independent
+lucky.rabbitfoot141@gmail.com                       Independent
+mailthelong@gmail.com                               Independent
+mail@eworm.de                                       Arch Linux
+markus456@gmail.com                                 MariaDB Corporation
+mg@webmail.us                                       Independent
+midenok@gmail.com                                   MariaDB Corporation
+mihyaeru21@gmail.com                                Independent
+mikko.jaakola@hotmail.fi                            Independent
+mocb28@gmail.com                                    GoSecure
+moonset20@gmail.com                                 Independent
+mostafa.hussein91@gmail.com                         Independent
+mschorm@centrum.cz                                  RedHat
+mysqlonarm@gmail.com                                Huawei
+nayuta.yanagisawa@hey.com                           MariaDB Corporation
+nia@NetBSD.org                                      NetBSD
+# Unsure of exact date
+nikitamalyavin@gmail.com                            Tempesta < 2019-06-01
+nikitamalyavin@gmail.com                            MariaDB Corporation
+noel@familie-kuntze.de                              Independent
+odenbach@uni-paderborn.de                           Independent
+# Unsure of exact date
+okokomichaels@outlook.com                           Independent < 2022-01-01
+okokomichaels@outlook.com                           Percona
+oli.sennhauser@bluewin.ch                           FromDual
+# Unsure of exact date
+olernov@gmail.com                                   Teramind < 2021-01-01
+olernov@gmail.com                                   MariaDB Corporation
+# Unsure of exact date
+otto@kekalainen.net                                 MariaDB Foundation < 2021-01-01
+otto@kekalainen.net                                 Amazon
+pali@cpan.org                                       Independent
+patrakov@gmail.com                                  Independent
+pkubaj@users.noreply.github.com                     HardenedBSD
+pmacontrol@68koncept.com                            Independent
+rahulanand16nov@gmail.com                           Independent
+rantal5030@gmail.com                                Independent
+razze@iki.fi                                        MariaDB Corporation
+redtree.dev1112@gmail.com                           Amazon
+rmfalves@gmail.com                                  Independent
+ro@CeBiTec.Uni-Bielefeld.DE                         Independent
+samuel.thibault@ens-lyon.org                        Independent
+sebastian_ml@gmx.net                                Independent
+seppo.jaakola@iki.fi                                Codership
+sergeikrivonos@gmail.com                            MariaDB Corporation
+serzh7214@mail.ru                                   Independent
+sh1ftr@protonmail.ch                                Independent
+shrinidhi.kaushik@gmail.com                         Independent
+sloonz@gmail.com                                    Independent
+splitice@users.noreply.github.com                   Independent
+sryze@protonmail.com                                Independent
+sysprg@gmail.com                                    MariaDB Corporation
+tkngsnsk313320@gmail.com                            Independent
+tomookam@live.jp                                    Amazon
+tuukka.pasanen@ilmi.fi                              MariaDB Foundation
+u16suzu@gmail.com                                   Independent
+unki@users.noreply.github.com                       Independent
+ustun@ustunozgur.com                                Independent
+vlad_lesin@mail.ru                                  MariaDB Corporation
+vladkakurin007@gmail.com                            Independent
+waynestxia@gmail.com                                Independent
+william.devries@gmail.com                           MariaDB Corporation
+wzssyqa@gmail.com                                   Independent
+xdavidwuph@gmail.com                                Independent
+xzhangxian@foxmail.com                              Independent
+zhaorenhai@hotmail.com                              Independent

--- a/metrics/gitdm_config/filetypes.txt
+++ b/metrics/gitdm_config/filetypes.txt
@@ -1,0 +1,362 @@
+# -*- coding:utf-8 -*-
+# Copyright (C)  2006 Libresoft
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option  any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors : Gregorio Robles <grex@gsyc.escet.urjc.es>
+# Authors : Germán Póo-Caamaño <gpoo@gnome.org>
+#
+# This file contains associations parameters regarding filetypes
+# (documentation, develompent, multimedia, images...)
+#
+# format:
+# filetype <type> <regex> [<comment>]
+#
+# Order:
+#   The list should keep an order, so filetypes can be counted properly.
+#   ie. we want ltmain.sh -> 'build' instead of 'code'.
+#
+#   If there is an filetype which is not in order but has values, it will
+#   be added at the end.
+#
+order image,translation,ui,multimedia,package,build,code,documentation,devel-doc
+#
+#
+# Code files (headers and the like included
+# (most common languages first
+#
+filetype code \.c$	# C
+filetype code \.pc$	# C
+filetype code \.ec$	# C
+filetype code \.ecp$	# C
+filetype code \.C$	# C++
+filetype code \.cpp$	# C++
+filetype code \.c\+\+$	# C++
+filetype code \.cxx$	# C++
+filetype code \.cc$	# C++
+filetype code \.pcc$	# C++
+filetype code \.cpy$	# C++
+filetype code \.h$	# C or C++ header
+filetype code \.hh$	# C++ header
+filetype code \.hpp$	# C++ header
+filetype code \.hxx$	# C++ header
+filetype code \.sh$	# Shell
+filetype code \.pl$	# Perl
+filetype code \.pm$	# Perl
+filetype code \.pod$	# Perl
+filetype code \.perl$	# Perl
+filetype code \.cgi$	# CGI
+filetype code \.php$	# PHP
+filetype code \.php3$	# PHP
+filetype code \.php4$	# PHP
+filetype code \.inc$	# PHP
+filetype code \.py$	# Python
+filetype code \.java$	# Java
+filetype code \.class$	# Java Class (or at least a class in some OOPL
+filetype code \.ada$	# ADA
+filetype code \.ads$	# ADA
+filetype code \.adb$	# ADA
+filetype code \.pad$	# ADA
+filetype code \.s$	# Assembly
+filetype code \.S$	# Assembly
+filetype code \.asm$	# Assembly
+filetype code \.awk$	# awk
+filetype code \.cs$	# C#
+filetype code \.csh$	# CShell (including tcsh
+filetype code \.cob$	# COBOL
+filetype code \.cbl$	# COBOL
+filetype code \.COB$	# COBOL
+filetype code \.CBL$	# COBOL
+filetype code \.exp$	# Expect
+filetype code \.l$	# (F lex
+filetype code \.ll$	# (F lex
+filetype code \.lex$	# (F lex
+filetype code \.f$	# Fortran
+filetype code \.f77$	# Fortran
+filetype code \.F$	# Fortran
+filetype code \.hs$	# Haskell
+filetype code \.lhs$	# Not preprocessed Haskell
+filetype code \.el$	# LISP (including Scheme
+filetype code \.scm$	# LISP (including Scheme
+filetype code \.lsp$	# LISP (including Scheme
+filetype code \.jl$	# LISP (including Scheme
+filetype code \.ml$	# ML
+filetype code \.ml3$	# ML
+filetype code \.m3$	# Modula3
+filetype code \.i3$	# Modula3
+filetype code \.m$	# Objective-C
+filetype code \.p$	# Pascal
+filetype code \.pas$	# Pascal
+filetype code \.rb$	# Ruby
+filetype code \.sed$	# sed
+filetype code \.tcl$	# TCL
+filetype code \.tk$	# TCL
+filetype code \.itk$	# TCL
+filetype code \.y$	# Yacc
+filetype code \.yy$	# Yacc
+filetype code \.idl$	# CORBA IDL
+filetype code \.gnorba$	# GNOME CORBA IDL
+filetype code \.oafinfo$	# GNOME OAF
+filetype code \.mcopclass$	# MCOP IDL compiler generated class
+filetype code \.autoforms$	# Autoform
+filetype code \.atf$	# Autoform
+filetype code \.gnuplot$
+filetype code \.xs$	# Shared library? Seen a lot of them in gnome-perl
+filetype code \.js$	# JavaScript (and who knows, maybe more
+filetype code \.patch$
+filetype code \.diff$	# Sometimes patches appear this way
+filetype code \.ids$	# Not really sure what this means
+filetype code \.upd$	# ¿¿¿??? (from Kcontrol
+filetype code $.ad$ 	# ¿¿¿??? (from Kdisplay and mc
+filetype code $.i$	# Appears in the kbindings for Qt
+filetype code $.pri$	# from Qt
+filetype code \.schema$	# Not really sure what this means
+filetype code \.fd$	# Something to do with latex
+filetype code \.cls$	# Something to do with latex
+filetype code \.pro$	# Postscript generation
+filetype code \.ppd$	# PDF generation
+filetype code \.dlg$	# Not really sure what this means
+filetype code \.plugin$	# Plug-in file
+filetype code \.dsp	# Microsoft Developer Studio Project File
+filetype code \.vim$	# vim syntax file
+filetype code \.trm$	# gnuplot term file
+filetype code \.font$	# Font mapping
+filetype code \.ccg$	# C++ files - Found in gtkmm*
+filetype code \.hg$	# C++ headers - Found in gtkmm*
+filetype code \.dtd	# XML Document Type Definition
+filetype code \.bat	# DOS batch files
+filetype code \.vala	# Vala
+filetype code \.py\.in$
+filetype code \.rhtml$	# eRuby
+filetype code \.sql$	# SQL script
+#
+#
+# Development documentation files (for hacking generally
+#
+filetype devel-doc ^readme.*$
+filetype devel-doc ^changelog.*
+filetype devel-doc ^todo.*$
+filetype devel-doc ^credits.*$
+filetype devel-doc ^authors.*$
+filetype devel-doc ^changes.*$
+filetype devel-doc ^news.*$
+filetype devel-doc ^install.*$
+filetype devel-doc ^hacking.*$
+filetype devel-doc ^copyright.*$
+filetype devel-doc ^licen(s|c)e.*$
+filetype devel-doc ^copying.*$
+filetype devel-doc manifest$
+filetype devel-doc faq$
+filetype devel-doc building$
+filetype devel-doc howto$
+filetype devel-doc design$
+filetype devel-doc \.files$
+filetype devel-doc files$
+filetype devel-doc subdirs$
+filetype devel-doc maintainers$
+filetype devel-doc developers$
+filetype devel-doc contributors$
+filetype devel-doc thanks$
+filetype devel-doc releasing$
+filetype devel-doc test$
+filetype devel-doc testing$
+filetype devel-doc build$
+filetype devel-doc comments?$
+filetype devel-doc bugs$
+filetype devel-doc buglist$
+filetype devel-doc problems$
+filetype devel-doc debug$
+filetype devel-doc hacks$
+filetype devel-doc hacking$
+filetype devel-doc versions?$
+filetype devel-doc mappings$
+filetype devel-doc tips$
+filetype devel-doc ideas?$
+filetype devel-doc spec$
+filetype devel-doc compiling$
+filetype devel-doc notes$
+filetype devel-doc missing$
+filetype devel-doc done$
+filetype devel-doc \.omf$	# XML-based format used in GNOME
+filetype devel-doc \.lsm$
+filetype devel-doc ^doxyfile$
+filetype devel-doc \.kdevprj$
+filetype devel-doc \.directory$
+filetype devel-doc \.dox$
+filetype devel-doc \.doap$
+#
+#
+# Building, compiling, configuration and CVS admin files
+#
+filetype build \.in.*$
+filetype build configure.*$
+filetype build makefile.*$
+filetype build config\.sub$
+filetype build config\.guess$
+filetype build config\.status$
+filetype build ltmain\.sh$
+filetype build autogen\.sh$
+filetype build config$
+filetype build conf$
+filetype build cvsignore$
+filetype build \.cfg$
+filetype build \.m4$
+filetype build \.mk$
+filetype build \.mak$
+filetype build \.make$
+filetype build \.mbx$
+filetype build \.protocol$
+filetype build \.version$
+filetype build mkinstalldirs$
+filetype build install-sh$
+filetype build rules$
+filetype build \.kdelnk$
+filetype build \.menu$
+filetype build linguas$	# Build translations
+filetype build potfiles.*$	# Build translations
+filetype build \.shlibs$	# Shared libraries
+# filetype build %debian%
+# filetype build %specs/%
+filetype build \.spec$	# It seems theyre necessary for RPM build
+filetype build \.def$	# build bootstrap for DLLs on win32
+#
+#
+# Documentation files
+#
+# filetype documentation doc/%
+# filetype documentation %HOWTO%
+filetype documentation \.html$
+filetype documentation \.txt$
+filetype documentation \.ps(\.gz|\.bz2)?$
+filetype documentation \.dvi(\.gz|\.bz2)?$
+filetype documentation \.lyx$
+filetype documentation \.tex$
+filetype documentation \.texi$
+filetype documentation \.pdf(\.gz|\.bz2)?$
+filetype documentation \.djvu$
+filetype documentation \.epub$
+filetype documentation \.sgml$
+filetype documentation \.docbook$
+filetype documentation \.wml$
+filetype documentation \.xhtml$
+filetype documentation \.phtml$
+filetype documentation \.shtml$
+filetype documentation \.htm$
+filetype documentation \.rdf$
+filetype documentation \.phtm$
+filetype documentation \.tmpl$
+filetype documentation \.ref$	# References
+filetype documentation \.css$
+# filetype documentation %tutorial%
+filetype documentation \.templates$
+filetype documentation \.dsl$
+filetype documentation \.ent$
+filetype documentation \.xml$
+filetype documentation \.xmi$
+filetype documentation \.xsl$
+filetype documentation \.entities$
+filetype documentation \.[1-7]$	# Man pages
+filetype documentation \.man$
+filetype documentation \.manpages$
+filetype documentation \.doc$
+filetype documentation \.rtf$
+filetype documentation \.wpd$
+filetype documentation \.qt3$
+filetype documentation man\d?/.*\.\d$
+filetype documentation \.docs$
+filetype documentation \.sdw$	# OpenOffice.org Writer document
+filetype documentation \.odt$	# OpenOffice.org document
+filetype documentation \.en$	# Files in English language
+filetype documentation \.de$	# Files in German
+filetype documentation \.es$	# Files in Spanish
+filetype documentation \.fr$	# Files in French
+filetype documentation \.it$	# Files in Italian
+filetype documentation \.cz$	# Files in Czech
+filetype documentation \.page$	# Mallard
+filetype documentation \.page.stub$	# Mallard stub
+#
+#
+# Images
+#
+filetype image \.png$
+filetype image \.jpg$
+filetype image \.jpeg$
+filetype image \.bmp$
+filetype image \.gif$
+filetype image \.xbm$
+filetype image \.eps$
+filetype image \.mng$
+filetype image \.pnm$
+filetype image \.pbm$
+filetype image \.ppm$
+filetype image \.pgm$
+filetype image \.gbr$
+filetype image \.svg$
+filetype image \.fig$
+filetype image \.tif$
+filetype image \.swf$
+filetype image \.svgz$
+filetype image \.shape$	# XML files used for shapes for instance in Kivio
+filetype image \.sml$	# XML files used for shapes for instance in Kivio
+filetype image \.bdf$	#  vfontcap  - Vector Font Capability Database (VFlib Version 2
+filetype image \.ico$
+filetype image \.dia$	# We consider .dia as images, I dont want them in unknown
+#
+#
+# Translation files
+#
+filetype translation \.po$
+filetype translation \.pot$
+filetype translation \.charset$
+filetype translation \.mo$
+#
+#
+# User interface files
+#
+filetype ui \.desktop$
+filetype ui \.ui$
+filetype ui \.xpm$
+filetype ui \.xcf$
+filetype ui \.3ds$
+filetype ui \.theme$
+filetype ui \.kimap$
+filetype ui \.glade$
+filetype ui \.gtkbuilder$
+filetype ui rc$
+#
+#
+# Sound files
+#
+filetype multimedia \.mp3$
+filetype multimedia \.ogg$
+filetype multimedia \.wav$
+filetype multimedia \.au$
+filetype multimedia \.mid$
+filetype multimedia \.vorbis$
+filetype multimedia \.midi$
+filetype multimedia \.arts$
+#
+#
+# Packages (yes, there are people who upload packages to the repo)
+#
+filetype package \.tar$
+filetype package \.tar.gz$
+filetype package \.tar.bz2$
+filetype package \.tar.xz$
+filetype package \.tgz$
+filetype package \.deb$
+filetype package \.rpm$
+filetype package \.srpm$
+filetype package \.ebuild$

--- a/metrics/gitdm_config/gitdm.config
+++ b/metrics/gitdm_config/gitdm.config
@@ -1,0 +1,3 @@
+EmailAliases gitdm_config/aliases
+EmailMap gitdm_config/domain-map
+EmailMap gitdm_config/employers


### PR DESCRIPTION
These metrics calculate contributor and contributor affiliation metrics
for commits. It currently uses a submodule to pull the Linux kernel
version of GitDM but this may well need to change as we customise it for
our usage.

There are some improvements to be made to this which are outlined in the
TODO.md. A contribution guide to the email mappings will eventually be
needed.