### PR TITLE
MDEV-30205 move /usr/share/mysql* to /usr/share/mariadb*

### DIFF
--- a/buildbot/maria-master.cfg
+++ b/buildbot/maria-master.cfg
@@ -1589,8 +1589,7 @@ fi
 # MTR
 #----------------
 
-cd /usr/share
-cd `find . -name mysql-test`
+cd `find /usr/share \( -name mysql-test -o -name mariadb-test \)`
 
 if test -f suite/plugins/pam/pam_mariadb_mtr.so; then
   for p in /lib*/security /lib*/*/security ; do
@@ -2273,7 +2272,7 @@ mysql -uroot $password_option --skip-column-names -e "select plugin_name, plugin
 
 rm -f /home/buildbot/ldd.old
 set +x
-for i in `sudo which mysqld | sed -e 's/mysqld$/mysql\*/'` `which mysql | sed -e 's/mysql$/mysql\*/'` `rpm -ql \`rpm -qa | grep MariaDB | xargs\` | grep -v 'mysql-test' | grep -v '/debug/' | grep '/plugin/' | sed -e 's/[^\/]*$/\*/' | sort | uniq | xargs`
+for i in `sudo which mysqld | sed -e 's/mysqld$/mysql\*/'` `which mysql | sed -e 's/mysql$/mysql\*/'` `rpm -ql \`rpm -qa | grep MariaDB | xargs\` | egrep -v '(mysql|mariadb)-test' | grep -v '/debug/' | grep '/plugin/' | sed -e 's/[^\/]*$/\*/' | sort | uniq | xargs`
 do
   echo "=== $i" >> /home/buildbot/ldd.old
   ldd $i | sort | sed 's/(.*)//' >> /home/buildbot/ldd.old
@@ -2429,7 +2428,7 @@ mysql -uroot $password_option --skip-column-names -e "select plugin_name, plugin
 
 rm -f /home/buildbot/ldd.new
 set +x
-for i in `sudo which mysqld | sed -e 's/mysqld$/mysql\*/'` `which mysql | sed -e 's/mysql$/mysql\*/'` `rpm -ql \`rpm -qa | grep MariaDB | xargs\` | grep -v 'mysql-test' | grep -v '/debug/' | grep '/plugin/' | sed -e 's/[^\/]*$/\*/' | sort | uniq | xargs`
+for i in `sudo which mysqld | sed -e 's/mysqld$/mysql\*/'` `which mysql | sed -e 's/mysql$/mysql\*/'` `rpm -ql \`rpm -qa | grep MariaDB | xargs\` | egrep -v '(mariadb|mysql)-test' | grep -v '/debug/' | grep '/plugin/' | sed -e 's/[^\/]*$/\*/' | sort | uniq | xargs`
 do
   # TODO: Remove after Q1 2023 release
   if [[ "$i" =~ ha_oqgraph.so ]] && [[ "%(buildername)s" =~ kvm-zyp-sles15 ]] && [[ "$major_version" =~ 10.[3-9] ]] ; then
@@ -2544,7 +2543,7 @@ arch=""" + arch + """
 # Turn off systemd tricks and write a normal coredump instead
 sudo sysctl -w 'kernel.core_pattern=core' || true
 
-cd /usr/share/mysql-test
+cd /usr/share/mysql-test || cd /usr/share/mariadb-test
 
 if test -f suite/plugins/pam/pam_mariadb_mtr.so; then
   for p in /lib*/security /lib*/*/security ; do
@@ -2870,7 +2869,7 @@ mysqltest --version
 # Run the tests
 #==============
 
-cd /usr/share/mysql-test
+cd /usr/share/mysql-test || cd /usr/share/mariadb-test
 perl mysql-test-run.pl  --verbose-restart --vardir="$(readlink -f /dev/shm/var)" --parallel=4 --force --retry=3 --max-save-core=0 --max-save-datadir=1 `cat collections/10.0-compatible.list | grep -v '#' | xargs`
 res=$?
 perl mysql-test-run.pl  --verbose-restart --vardir="$(readlink -f /dev/shm/var)" --parallel=4 --ps-protocol --force --retry=3 --max-save-core=0 --max-save-datadir=1 `cat collections/10.0-compatible.list | grep -v '#' | xargs`
@@ -3083,7 +3082,7 @@ fi
 
 rm -vf *-debuginfo-*
 sudo yum install -y --nogpgcheck MariaDB-server-*.rpm MariaDB-test-*.rpm MariaDB-backup-*.rpm MariaDB-compat-*.rpm MariaDB-client-*.rpm MariaDB-common-*.rpm galera*.rpm
-cd /usr/share/mysql-test
+cd /usr/share/mysql-test || cd /usr/share/mariadb-test
 # All *ssl* tests, removing ./ prefix right away
 find . -name '*ssl*.test' | sed -e 's/^\.\///g' > /tmp/test.list
 # All tests calling including certain functions (will produce an excessive list, with false positives)

--- a/buildbot/steps/mtr.deb.sh
+++ b/buildbot/steps/mtr.deb.sh
@@ -23,7 +23,7 @@ then
   echo "Warning: Could not install gdb, proceeding without it"
 fi
 
-cd /usr/share/mysql/mysql-test
+cd /usr/share/mysql/mysql-test || cd /usr/share/mariadb/mariadb-test
 
 mtr_opts=" --verbose-restart --force --retry=2 --max-save-core=0 --max-save-datadir=1 --vardir=""$(readlink -f /dev/shm/var)"
 


### PR DESCRIPTION
Prepare for the move using /usr/share/mariadb* if /usr/share/mysql* fails.

server change: https://github.com/MariaDB/server/pull/2392