### PR TITLE
MDEV-28986: rpl tests sometimes failing on freebsd builders

### DIFF
--- a/buildbot/maria-master.cfg
+++ b/buildbot/maria-master.cfg
@@ -4815,7 +4815,9 @@ fi
             command=["runvm"] + args + ["--logfile=kernel_"+getport()+".log", "vm-tmp-"+getport()+".qcow2",
             WithProperties("""
 set -x
-sudo mount -t tmpfs tmpfs /tmp
+# Don't use tmpfs due to https://jira.mariadb.org/browse/MDEV-28986
+# The FreeBSD bug: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=272678
+#sudo mount -t tmpfs tmpfs /tmp
 cat /etc/os-release
 cd /usr/local/share/mysql-test || cd /usr/local/share/mariadb-test
 nCPU=$(sysctl hw | grep hw.ncpu | awk '{print $2}')
@@ -4974,7 +4976,9 @@ mv "$(cat ../../bindistname.txt).tar.gz" ../
             WithProperties("= scp -P "+getport()+" "+kvm_scpopt+" %(bindistname)s.tar.gz buildbot@localhost:buildbot/"),
             WithProperties("""
 set -x
-sudo mount -t tmpfs tmpfs /tmp
+# Don't use tmpfs due to https://jira.mariadb.org/browse/MDEV-28986
+# The FreeBSD bug: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=272678
+#sudo mount -t tmpfs tmpfs /tmp
 cat /etc/os-release
 df -kT
 cd buildbot


### PR DESCRIPTION
Avoid using tmpfs as --vardir for FreeBSD tests. It causes test failures due to a FreeBSD bug https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=272678 .